### PR TITLE
chore(systemd): add systemd service files

### DIFF
--- a/extra/systemd/rustypaste.env
+++ b/extra/systemd/rustypaste.env
@@ -1,0 +1,2 @@
+# To enable basic HTTP auth, set the AUTH_TOKEN
+AUTH_TOKEN=""

--- a/extra/systemd/rustypaste.service
+++ b/extra/systemd/rustypaste.service
@@ -1,0 +1,31 @@
+[Unit]
+Description=Rustypaste server
+After=network-online.target
+Wants=network-online.target systemd-networkd-wait-online.service
+
+[Service]
+User=rustypaste
+Group=rustypaste
+ExecStart=/usr/bin/rustypaste
+ReadWritePaths=/var/lib/rustypaste
+ReadOnlyPaths=/etc/rustypaste
+
+WorkingDirectory=/var/lib/rustypaste
+Environment="CONFIG=/etc/rustypaste/config.toml"
+EnvironmentFile=/etc/rustypaste/rustypaste.env
+
+# Hardening options
+CapabilityBoundingSet=
+AmbientCapabilities=
+NoNewPrivileges=true
+ProtectHome=true
+ProtectSystem=strict
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectControlGroups=true
+PrivateTmp=true
+PrivateDevices=true
+LockPersonality=true
+
+[Install]
+WantedBy=multi-user.target

--- a/extra/systemd/rustypaste.sysusers
+++ b/extra/systemd/rustypaste.sysusers
@@ -1,0 +1,1 @@
+u rustypaste - "Minimal file upload/pastebin service" /var/lib/rustypaste

--- a/extra/systemd/rustypaste.tmpfiles
+++ b/extra/systemd/rustypaste.tmpfiles
@@ -1,0 +1,1 @@
+d /var/lib/rustypaste 0750 rustypaste rustypaste


### PR DESCRIPTION
Add systemd files to serve files from /var/lib/rustypaste, automatic
user creation via systemd-sysusers and AUTH_TOKEN configuration via
rustypaste.env in /etc/rustypaste/rustypaste.env.

implements #16