### PR TITLE
chore(config): do not check for duplicate files by default

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -26,5 +26,5 @@ mime_blacklist = [
     "application/java-archive",
     "application/java-vm"
 ]
-duplicate_files = false
+duplicate_files = true
 delete_expired_files = { enabled = true, interval = "1h" }


### PR DESCRIPTION
It is an expensive operation to do on slower hardware and can take unreasonable amount of time for bigger files