### PR TITLE
feat(server): add landing page

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -7,6 +7,18 @@ address="127.0.0.1:8000"
 max_content_length="10MB"
 upload_path="./upload"
 timeout="30s"
+landing_page = """
+Submit files via HTTP POST here:
+    curl -F 'file=@example.txt' <server>"
+This will return the finished URL.
+
+The server administrator might remove any pastes that they do not personally
+want to host.
+
+If you are the server administrator and want to change this page, just go
+into your config file and change it!
+a
+"""
 
 [paste]
 random_url = { enabled = true, type = "petname", words = 2, separator = "-" }

--- a/config.toml
+++ b/config.toml
@@ -7,8 +7,7 @@ address="127.0.0.1:8000"
 max_content_length="10MB"
 upload_path="./upload"
 timeout="30s"
-landing_page = """
-Submit files via HTTP POST here:
+landing_page="""Submit files via HTTP POST here:
     curl -F 'file=@example.txt' <server>"
 This will return the finished URL.
 
@@ -16,10 +15,13 @@ The server administrator might remove any pastes that they do not personally
 want to host.
 
 If you are the server administrator and want to change this page, just go
-into your config file and change it!
+into your config file and change it! If you change the expiry time, it is
+recommended that you do.
 
 Check out the GitHub repository at {REPOSITORY}!
-"""
+
+By default, pastes expire every hour. The server admin may or may not have
+changed this."""
 
 [paste]
 random_url = { enabled = true, type = "petname", words = 2, separator = "-" }

--- a/config.toml
+++ b/config.toml
@@ -18,7 +18,7 @@ If you are the server administrator and want to change this page, just go
 into your config file and change it! If you change the expiry time, it is
 recommended that you do.
 
-Check out the GitHub repository at {REPOSITORY}!
+Check out the GitHub repository at https://github.com/orhun/rustypaste
 
 By default, pastes expire every hour. The server admin may or may not have
 changed this."""

--- a/config.toml
+++ b/config.toml
@@ -17,7 +17,8 @@ want to host.
 
 If you are the server administrator and want to change this page, just go
 into your config file and change it!
-a
+
+Check out the GitHub repository at {REPOSITORY}!
 """
 
 [paste]

--- a/fixtures/test-server-landing-page/config.toml
+++ b/fixtures/test-server-landing-page/config.toml
@@ -1,0 +1,10 @@
+[server]
+address="127.0.0.1:8000"
+max_content_length="10MB"
+upload_path="./upload"
+landing_page="awesome_landing"
+
+[paste]
+random_url = { enabled = false, type = "petname", words = 2, separator = "-" }
+default_extension = "txt"
+duplicate_files = false

--- a/fixtures/test-server-landing-page/test.sh
+++ b/fixtures/test-server-landing-page/test.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+landing_page="awesome_landing"
+
+setup() {
+  :;
+}
+
+run_test() {
+  result=$(curl -s localhost:8000)
+  test "$landing_page" = "$result"
+}
+
+teardown() {
+  :;
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -41,6 +41,8 @@ pub struct ServerConfig {
     pub timeout: Option<Duration>,
     /// Authentication token.
     pub auth_token: Option<String>,
+    /// Landing page text.
+    pub landing_page: Option<String>,
 }
 
 /// Paste configuration.

--- a/src/server.rs
+++ b/src/server.rs
@@ -8,7 +8,7 @@ use crate::util;
 use crate::AUTH_TOKEN_ENV;
 use actix_files::NamedFile;
 use actix_multipart::Multipart;
-use actix_web::{error, get, post, web, Error, HttpRequest, HttpResponse, Responder};
+use actix_web::{error, get, post, web, Error, HttpRequest, HttpResponse};
 use awc::Client;
 use byte_unit::Byte;
 use futures_util::stream::StreamExt;
@@ -25,9 +25,13 @@ The server administrator might remove any pastes that they do not personally
 want to host.
 
 If you are the server administrator and want to change this page, just go
-into your config file and change it!
+into your config file and change it! If you change the expiry time, it is
+recommended that you do.
 
-Check out the GitHub repository at {REPOSITORY}!"#;
+Check out the GitHub repository at {REPOSITORY}!
+
+By default, pastes expire every hour. The server admin may or may not have
+changed this."#;
 
 /// Shows the landing page.
 #[get("/")]

--- a/src/server.rs
+++ b/src/server.rs
@@ -35,9 +35,7 @@ changed this."#;
 
 /// Shows the landing page.
 #[get("/")]
-async fn index(
-    config: web::Data<RwLock<Config>>
-) -> Result<HttpResponse, Error> {
+async fn index(config: web::Data<RwLock<Config>>) -> Result<HttpResponse, Error> {
     let config = config
         .read()
         .map_err(|_| error::ErrorInternalServerError("cannot acquire config"))?;
@@ -45,8 +43,7 @@ async fn index(
         Some(page) => page,
         None => LANDING_PAGE.to_string(),
     };
-    Ok(HttpResponse::Ok()
-        .body(landing_page.replace("{REPOSITORY}", env!("CARGO_PKG_HOMEPAGE"))))
+    Ok(HttpResponse::Ok().body(landing_page.replace("{REPOSITORY}", env!("CARGO_PKG_HOMEPAGE"))))
 }
 
 /// Serves a file from the upload directory.

--- a/src/server.rs
+++ b/src/server.rs
@@ -281,12 +281,18 @@ mod tests {
 
     #[actix_web::test]
     async fn test_index() {
-        let app = test::init_service(App::new().service(index)).await;
+        let config = Config::default();
+        let app = test::init_service(
+            App::new()
+                .app_data(Data::new(RwLock::new(config)))
+                .service(index),
+        )
+        .await;
         let request = TestRequest::default()
             .insert_header(("content-type", "text/plain"))
             .to_request();
         let response = test::call_service(&app, request).await;
-        assert_eq!(StatusCode::FOUND, response.status());
+        assert_eq!(StatusCode::OK, response.status());
     }
 
     #[actix_web::test]

--- a/src/server.rs
+++ b/src/server.rs
@@ -25,7 +25,9 @@ The server administrator might remove any pastes that they do not personally
 want to host.
 
 If you are the server administrator and want to change this page, just go
-into your config file and change it!"#;
+into your config file and change it!
+
+Check out the GitHub repository at {REPOSITORY}!"#;
 
 /// Shows the landing page.
 #[get("/")]
@@ -40,7 +42,7 @@ async fn index(
         None => LANDING_PAGE.to_string(),
     };
     Ok(HttpResponse::Ok()
-        .body(landing_page))
+        .body(landing_page.replace("{REPOSITORY}", env!("CARGO_PKG_HOMEPAGE"))))
 }
 
 /// Serves a file from the upload directory.


### PR DESCRIPTION
Fixes orhun/rustypaste#13

The default landing page is set as a const in the binary, but is configurable with the server.landing_page key. Should the key be in another section (i.e. not `[server]`? Handling is added for when the config file doesn't have any landing page. I updated the default config.toml.