### PR TITLE
feat(server): expose version as endpoint

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -7,6 +7,7 @@ address="127.0.0.1:8000"
 max_content_length="10MB"
 upload_path="./upload"
 timeout="30s"
+expose_version=true
 landing_page="""Submit files via HTTP POST here:
     curl -F 'file=@example.txt' <server>"
 This will return the finished URL.

--- a/src/config.rs
+++ b/src/config.rs
@@ -43,6 +43,8 @@ pub struct ServerConfig {
     pub auth_token: Option<String>,
     /// Landing page text.
     pub landing_page: Option<String>,
+    /// Expose version.
+    pub expose_version: Option<bool>,
 }
 
 /// Paste configuration.


### PR DESCRIPTION
Configurable and behind authentication. By default disabled.

Fixes: #27

Signed-off-by: Leonidas Spyropoulos <artafinde@archlinux.org>