### PR TITLE
fix(config): don't expose version endpoint in default config

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -7,7 +7,7 @@ address="127.0.0.1:8000"
 max_content_length="10MB"
 upload_path="./upload"
 timeout="30s"
-expose_version=true
+expose_version=false
 landing_page="""Submit files via HTTP POST here:
     curl -F 'file=@example.txt' <server>"
 This will return the finished URL.


### PR DESCRIPTION
As mentioned on the release notes the default should have been to not expose the `/version` config.

This is affecting Archlinux release.