### PR TITLE
feat(server): support one shot URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,7 @@ The public instance is available at [https://rustypaste.shuttleapp.rs](https://r
   - supports expiring links
     - auto-expiration of files (optional)
     - auto-deletion of expired files (optional)
-  - supports one shot links (can only be viewed once)
-  - supports one shot urls (can only be viewed once)
+  - supports one shot links/URLs (can only be viewed once)
   - guesses MIME types
     - supports overriding and blacklisting
     - supports forcing to download via `?download=true`
@@ -143,7 +142,7 @@ $ curl -F "file=@x.txt" -H "expire:10min" "<server_address>"
 
 (supported units: `ns`, `us`, `ms`, `sec`, `min`, `hours`, `days`, `weeks`, `months`, `years`)
 
-#### One shot
+#### One shot files
 
 ```sh
 $ curl -F "oneshot=@x.txt" "<server_address>"

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ The public instance is available at [https://rustypaste.shuttleapp.rs](https://r
     - auto-expiration of files (optional)
     - auto-deletion of expired files (optional)
   - supports one shot links (can only be viewed once)
+  - supports one shot urls (can only be viewed once)
   - guesses MIME types
     - supports overriding and blacklisting
     - supports forcing to download via `?download=true`
@@ -146,6 +147,12 @@ $ curl -F "file=@x.txt" -H "expire:10min" "<server_address>"
 
 ```sh
 $ curl -F "oneshot=@x.txt" "<server_address>"
+```
+
+#### One shot URLs
+
+```sh
+$ curl -F "oneshot_url=https://example.com" "<server_address>"
 ```
 
 #### URL shortening

--- a/fixtures/test-oneshot-url/config.toml
+++ b/fixtures/test-oneshot-url/config.toml
@@ -1,0 +1,9 @@
+[server]
+address="127.0.0.1:8000"
+max_content_length="10MB"
+upload_path="./upload"
+
+[paste]
+random_url = { enabled = false, type = "petname", words = 2, separator = "-" }
+default_extension = "txt"
+duplicate_files = false

--- a/fixtures/test-oneshot-url/test.sh
+++ b/fixtures/test-oneshot-url/test.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+url="https://orhun.dev/"
+
+setup() {
+  :;
+}
+
+run_test() {
+  file_url=$(curl -s -F "oneshot_url=$url" localhost:8000)
+  test "$url" = $(curl -Ls -w %{url_effective} -o /dev/null "$file_url")
+  test "$url" = "$(cat upload/oneshot_url/oneshot_url.*)"
+
+  result="$(curl -s $file_url)"
+  test "file is not found or expired :(" = "$result"
+}
+
+teardown() {
+  rm -r upload
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,7 +52,7 @@ fn setup(config_folder: &Path) -> IoResult<(Data<RwLock<Config>>, ServerConfig, 
 
     // Create necessary directories.
     fs::create_dir_all(&server_config.upload_path)?;
-    for paste_type in &[PasteType::Url, PasteType::Oneshot] {
+    for paste_type in &[PasteType::Url, PasteType::Oneshot, PasteType::OneshotUrl] {
         fs::create_dir_all(paste_type.get_path(&server_config.upload_path))?;
     }
 

--- a/src/paste.rs
+++ b/src/paste.rs
@@ -23,7 +23,7 @@ pub enum PasteType {
     Oneshot,
     /// A file that only contains an URL.
     Url,
-    /// A oneshot url
+    /// A oneshot url.
     OneshotUrl,
 }
 

--- a/src/paste.rs
+++ b/src/paste.rs
@@ -23,6 +23,8 @@ pub enum PasteType {
     Oneshot,
     /// A file that only contains an URL.
     Url,
+    /// A oneshot url
+    OneshotUrl,
 }
 
 impl<'a> TryFrom<&'a ContentDisposition> for PasteType {
@@ -34,6 +36,8 @@ impl<'a> TryFrom<&'a ContentDisposition> for PasteType {
             Ok(Self::RemoteFile)
         } else if content_disposition.has_form_field("oneshot") {
             Ok(Self::Oneshot)
+        } else if content_disposition.has_form_field("oneshot_url") {
+            Ok(Self::OneshotUrl)
         } else if content_disposition.has_form_field("url") {
             Ok(Self::Url)
         } else {
@@ -49,6 +53,7 @@ impl PasteType {
             Self::File | Self::RemoteFile => String::new(),
             Self::Oneshot => String::from("oneshot"),
             Self::Url => String::from("url"),
+            Self::OneshotUrl => String::from("oneshot_url"),
         }
     }
 
@@ -220,8 +225,9 @@ impl Paste {
             .paste
             .random_url
             .generate()
-            .unwrap_or_else(|| PasteType::Url.get_dir());
-        let mut path = PasteType::Url
+            .unwrap_or_else(|| self.type_.get_dir());
+        let mut path = self
+            .type_
             .get_path(&config.server.upload_path)
             .join(&file_name);
         if let Some(timestamp) = expiry_date {

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,12 +1,11 @@
-use crate::{
-    auth,
-    config::Config,
-    file::Directory,
-    header::{self, ContentDisposition},
-    mime as mime_util,
-    paste::{Paste, PasteType},
-    util, AUTH_TOKEN_ENV,
-};
+use crate::auth;
+use crate::config::Config;
+use crate::file::Directory;
+use crate::header::{self, ContentDisposition};
+use crate::mime as mime_util;
+use crate::paste::{Paste, PasteType};
+use crate::util;
+use crate::AUTH_TOKEN_ENV;
 use actix_files::NamedFile;
 use actix_multipart::Multipart;
 use actix_web::{error, get, post, web, Error, HttpRequest, HttpResponse};
@@ -14,7 +13,10 @@ use awc::Client;
 use byte_unit::Byte;
 use futures_util::stream::StreamExt;
 use serde::Deserialize;
-use std::{convert::TryFrom, env, fs, sync::RwLock};
+use std::convert::TryFrom;
+use std::env;
+use std::fs;
+use std::sync::RwLock;
 
 /// Shows the landing page.
 #[get("/")]

--- a/src/util.rs
+++ b/src/util.rs
@@ -55,24 +55,29 @@ pub fn glob_match_file(mut path: PathBuf) -> Result<PathBuf, ActixError> {
 ///
 /// Fail-safe, omits errors.
 pub fn get_expired_files(base_path: &Path) -> Vec<PathBuf> {
-    [PasteType::File, PasteType::Oneshot, PasteType::Url]
-        .into_iter()
-        .filter_map(|v| glob(&v.get_path(base_path).join("*.[0-9]*").to_string_lossy()).ok())
-        .flat_map(|glob| glob.filter_map(|v| v.ok()).collect::<Vec<PathBuf>>())
-        .filter(|path| {
-            if let Some(extension) = path
-                .extension()
-                .and_then(|v| v.to_str())
-                .and_then(|v| v.parse().ok())
-            {
-                get_system_time()
-                    .map(|system_time| system_time > Duration::from_millis(extension))
-                    .unwrap_or(false)
-            } else {
-                false
-            }
-        })
-        .collect()
+    [
+        PasteType::File,
+        PasteType::Oneshot,
+        PasteType::Url,
+        PasteType::OneshotUrl,
+    ]
+    .into_iter()
+    .filter_map(|v| glob(&v.get_path(base_path).join("*.[0-9]*").to_string_lossy()).ok())
+    .flat_map(|glob| glob.filter_map(|v| v.ok()).collect::<Vec<PathBuf>>())
+    .filter(|path| {
+        if let Some(extension) = path
+            .extension()
+            .and_then(|v| v.to_str())
+            .and_then(|v| v.parse().ok())
+        {
+            get_system_time()
+                .map(|system_time| system_time > Duration::from_millis(extension))
+                .unwrap_or(false)
+        } else {
+            false
+        }
+    })
+    .collect()
 }
 
 /// Returns the SHA256 digest of the given input.


### PR DESCRIPTION
Fix #38 

# Summary

This adds support for a new paste type `OneshotUrl`.

# Notes

- Add enum `PasteType::OneshotUrl`.
- Set content disposition to `oneshot_url`
- Add test to ensure that a oneshot_url is not found after making the first request

PS: It's totally possible I might have missed something. Honestly I don't fully understand the logic for how the files get deleted but I tried to follow the existing `oneshot` design (which seems to just rename the file with current timestamp so I did the same). The test I added does seem to work so hopefully this does the job.