### PR TITLE
feat(server): allow configuring the content type for landing page

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -31,6 +31,7 @@ changed this.
 Check out the GitHub repository at https://github.com/orhun/rustypaste
 Command line tool is available  at https://github.com/orhun/rustypaste-cli
 """
+landing_page_content_type = "text/plain; charset=utf-8"
 
 [paste]
 random_url = { enabled = true, type = "petname", words = 2, separator = "-" }

--- a/fixtures/test-server-landing-page/config.toml
+++ b/fixtures/test-server-landing-page/config.toml
@@ -3,6 +3,7 @@ address="127.0.0.1:8000"
 max_content_length="10MB"
 upload_path="./upload"
 landing_page="awesome_landing"
+landing_page_content_type = "text/plain; charset=utf-8"
 
 [paste]
 random_url = { enabled = false, type = "petname", words = 2, separator = "-" }

--- a/shuttle/config.toml
+++ b/shuttle/config.toml
@@ -29,6 +29,7 @@ If you liked this, consider supporting me: https://donate.orhun.dev <3
 
 🦀
 """
+landing_page_content_type = "text/plain; charset=utf-8"
 
 [paste]
 # random_url = { enabled = true, type = "petname", words = 2, separator = "-" }

--- a/src/config.rs
+++ b/src/config.rs
@@ -45,6 +45,8 @@ pub struct ServerConfig {
     pub auth_token: Option<String>,
     /// Landing page text.
     pub landing_page: Option<String>,
+    /// Landing page content-type
+    pub landing_page_content_type: Option<String>,
     /// Expose version.
     pub expose_version: Option<bool>,
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -24,7 +24,11 @@ async fn index(config: web::Data<RwLock<Config>>) -> Result<HttpResponse, Error>
     let config = config
         .read()
         .map_err(|_| error::ErrorInternalServerError("cannot acquire config"))?;
-    let content_type = config.server.landing_page_content_type.clone().unwrap_or("text/plain; charset=utf-8".to_string());
+    let content_type = config
+        .server
+        .landing_page_content_type
+        .clone()
+        .unwrap_or("text/plain; charset=utf-8".to_string());
     match &config.server.landing_page {
         Some(page) => Ok(HttpResponse::Ok()
             .content_type(content_type)

--- a/src/server.rs
+++ b/src/server.rs
@@ -24,9 +24,10 @@ async fn index(config: web::Data<RwLock<Config>>) -> Result<HttpResponse, Error>
     let config = config
         .read()
         .map_err(|_| error::ErrorInternalServerError("cannot acquire config"))?;
+    let content_type = config.server.landing_page_content_type.clone().unwrap_or("text/plain; charset=utf-8".to_string());
     match &config.server.landing_page {
         Some(page) => Ok(HttpResponse::Ok()
-            .content_type("text/plain; charset=\"UTF-8\"")
+            .content_type(content_type)
             .body(page.clone())),
         None => Ok(HttpResponse::Found()
             .append_header(("Location", env!("CARGO_PKG_HOMEPAGE")))


### PR DESCRIPTION
I realized that I don't need to implement this in a repo at all.  The user can already set a custom landing page in the config.  The only thing I needed to change was the content type so that the browser rendered it.  This makes the landing page content type available in the configuration.

Fixes #39