### PR TITLE
feat(server): honor X-Forward-* headers

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -157,7 +157,7 @@ async fn main() -> IoResult<()> {
         App::new()
             .app_data(Data::clone(&config))
             .app_data(Data::new(http_client))
-            .wrap(Logger::default())
+            .wrap(Logger::new("%{r}a \"%r\" %s %b \"%{Referer}i\" \"%{User-Agent}i\" %T"))
             .wrap(ContentLengthLimiter::new(
                 server_config.max_content_length.get_bytes(),
             ))
@@ -197,7 +197,7 @@ async fn actix_web(
             web::scope("")
                 .app_data(Data::clone(&config))
                 .app_data(Data::new(http_client))
-                .wrap(Logger::default())
+                .wrap(Logger::new("%{r}a \"%r\" %s %b \"%{Referer}i\" \"%{User-Agent}i\" %T"))
                 .wrap(ContentLengthLimiter::new(
                     server_config.max_content_length.get_bytes(),
                 ))

--- a/src/main.rs
+++ b/src/main.rs
@@ -157,7 +157,9 @@ async fn main() -> IoResult<()> {
         App::new()
             .app_data(Data::clone(&config))
             .app_data(Data::new(http_client))
-            .wrap(Logger::new("%{r}a \"%r\" %s %b \"%{Referer}i\" \"%{User-Agent}i\" %T"))
+            .wrap(Logger::new(
+                "%{r}a \"%r\" %s %b \"%{Referer}i\" \"%{User-Agent}i\" %T",
+            ))
             .wrap(ContentLengthLimiter::new(
                 server_config.max_content_length.get_bytes(),
             ))
@@ -197,7 +199,9 @@ async fn actix_web(
             web::scope("")
                 .app_data(Data::clone(&config))
                 .app_data(Data::new(http_client))
-                .wrap(Logger::new("%{r}a \"%r\" %s %b \"%{Referer}i\" \"%{User-Agent}i\" %T"))
+                .wrap(Logger::new(
+                    "%{r}a \"%r\" %s %b \"%{Referer}i\" \"%{User-Agent}i\" %T",
+                ))
                 .wrap(ContentLengthLimiter::new(
                     server_config.max_content_length.get_bytes(),
                 ))

--- a/src/server.rs
+++ b/src/server.rs
@@ -128,7 +128,7 @@ async fn version(
         .read()
         .map_err(|_| error::ErrorInternalServerError("cannot acquire config"))?;
     let connection = request.connection_info().clone();
-    let host = connection.peer_addr().unwrap_or("unknown host");
+    let host = connection.realip_remote_addr().unwrap_or("unknown host");
     auth::check(
         host,
         request.headers(),
@@ -153,7 +153,7 @@ async fn upload(
     config: web::Data<RwLock<Config>>,
 ) -> Result<HttpResponse, Error> {
     let connection = request.connection_info().clone();
-    let host = connection.peer_addr().unwrap_or("unknown host");
+    let host = connection.realip_remote_addr().unwrap_or("unknown host");
     let server_url = match config
         .read()
         .map_err(|_| error::ErrorInternalServerError("cannot acquire config"))?


### PR DESCRIPTION
Behind a reverse proxy, the log entries always showed the IP address of the reverse proxy. With this change the real IP address of the client is shown. Since the IP address is only used for info in the log, there are no security implications.

closes #54