### PR TITLE
docs(readme): list all supported units for expiry

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,19 @@ $ rpaste -
 $ curl -F "file=@x.txt" -H "expire:10min" "<server_address>"
 ```
 
-(supported units: `ns`, `us`, `ms`, `sec`, `min`, `hours`, `days`, `weeks`, `months`, `years`)
+supported units:
+
+- `nsec`, `ns`
+- `usec`, `us`
+- `msec`, `ms`
+- `seconds`, `second`, `sec`, `s`
+- `minutes`, `minute`, `min`, `m`
+- `hours`, `hour`, `hr`, `h`
+- `days`, `day`, `d`
+- `weeks`, `week`, `w`
+- `months`, `month`, `M`
+- `years`, `year`, `y`
+
 
 #### One shot files
 


### PR DESCRIPTION
These suffixes are also supported in the `config.toml`.

---

The duration is not consistently used. e.g. in the `config.toml` it says `default_expiry = "1h"` and not `default_expiry = "1hours"` as it is shown in the README. Also, I think people are rather used to single character duration units like s, m, h, d, w, y.

So I believe listing all supported units is useful for usability and consistency.
