### PR TITLE
feat(server): support a file for the landing page

### DIFF
--- a/fixtures/test-server-landing-page-file/config.toml
+++ b/fixtures/test-server-landing-page-file/config.toml
@@ -1,0 +1,12 @@
+[server]
+address="127.0.0.1:8000"
+max_content_length="10MB"
+upload_path="./upload"
+landing_page="awesome_landing"
+landing_page_file="page.txt"
+landing_page_content_type = "text/plain; charset=utf-8"
+
+[paste]
+random_url = { enabled = false, type = "petname", words = 2, separator = "-" }
+default_extension = "txt"
+duplicate_files = false

--- a/fixtures/test-server-landing-page-file/test.sh
+++ b/fixtures/test-server-landing-page-file/test.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+landing_page="awesome_landing_from_file"
+
+setup() {
+  echo $landing_page >page.txt
+}
+
+run_test() {
+  result=$(curl -s localhost:8000)
+  test "$landing_page" = "$result"
+}
+
+teardown() {
+  rm page.txt
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -45,6 +45,8 @@ pub struct ServerConfig {
     pub auth_token: Option<String>,
     /// Landing page text.
     pub landing_page: Option<String>,
+    /// Landing page file.
+    pub landing_page_file: Option<String>,
     /// Landing page content-type
     pub landing_page_content_type: Option<String>,
     /// Expose version.

--- a/src/server.rs
+++ b/src/server.rs
@@ -33,10 +33,10 @@ async fn index(config: web::Data<RwLock<Config>>) -> Result<HttpResponse, Error>
     match &config.server.landing_page_file {
         Some(file) => {
             let file_contents = fs::read_to_string(file).unwrap_or("".to_string());
-            if file_contents.is_empty() == false {
+            if !file_contents.is_empty() {
                 return Ok(HttpResponse::Ok()
                     .content_type(content_type)
-                    .body(file_contents.clone()));
+                    .body(file_contents));
             }
         },
         None => (),

--- a/src/server.rs
+++ b/src/server.rs
@@ -29,6 +29,19 @@ async fn index(config: web::Data<RwLock<Config>>) -> Result<HttpResponse, Error>
         .landing_page_content_type
         .clone()
         .unwrap_or("text/plain; charset=utf-8".to_string());
+
+    match &config.server.landing_page_file {
+        Some(file) => {
+            let file_contents = fs::read_to_string(file).unwrap_or("".to_string());
+            if file_contents.is_empty() == false {
+                return Ok(HttpResponse::Ok()
+                    .content_type(content_type)
+                    .body(file_contents.clone()));
+            }
+        },
+        None => (),
+    }
+
     match &config.server.landing_page {
         Some(page) => Ok(HttpResponse::Ok()
             .content_type(content_type)

--- a/src/server.rs
+++ b/src/server.rs
@@ -38,7 +38,7 @@ async fn index(config: web::Data<RwLock<Config>>) -> Result<HttpResponse, Error>
                     .content_type(content_type)
                     .body(file_contents));
             }
-        },
+        }
         None => (),
     }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -414,7 +414,6 @@ mod tests {
             .to_request();
         let response = test::call_service(&app, request).await;
         assert_eq!(StatusCode::FOUND, response.status());
-        //assert_body(response.into_body(), "landing page").await?;
         Ok(())
     }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -29,20 +29,11 @@ async fn index(config: web::Data<RwLock<Config>>) -> Result<HttpResponse, Error>
         .landing_page_content_type
         .clone()
         .unwrap_or("text/plain; charset=utf-8".to_string());
-
-    match &config.server.landing_page_file {
-        Some(file) => {
-            let file_contents = fs::read_to_string(file).unwrap_or("".to_string());
-            if !file_contents.is_empty() {
-                return Ok(HttpResponse::Ok()
-                    .content_type(content_type)
-                    .body(file_contents));
-            }
-        }
-        None => (),
+    let mut landing_page = config.server.landing_page.clone();
+    if let Some(file) = &config.server.landing_page_file {
+        landing_page = fs::read_to_string(file).ok();
     }
-
-    match &config.server.landing_page {
+    match &landing_page {
         Some(page) => Ok(HttpResponse::Ok()
             .content_type(content_type)
             .body(page.clone())),

--- a/src/server.rs
+++ b/src/server.rs
@@ -402,7 +402,7 @@ mod tests {
         let filename = "landing_page.txt";
         let mut config = Config::default();
         config.server.landing_page = Some(String::from("landing page"));
-        config.server.landing_page_file = Some(String::from(filename.to_string()));
+        config.server.landing_page_file = Some(filename.to_string());
         let app = test::init_service(
             App::new()
                 .app_data(Data::new(RwLock::new(config)))

--- a/src/server.rs
+++ b/src/server.rs
@@ -294,12 +294,12 @@ mod tests {
     use actix_web::App;
     use awc::ClientBuilder;
     use glob::glob;
+    use std::fs::File;
+    use std::io::Write;
     use std::path::PathBuf;
     use std::str;
     use std::thread;
     use std::time::Duration;
-    use std::fs::File;
-    use std::io::Write;
 
     fn get_multipart_request(data: &str, name: &str, filename: &str) -> TestRequest {
         let multipart_data = format!(


### PR DESCRIPTION
As contemplated in #52, this PR adds another config option `landing_page_file`.

If the file cannot be found, it will fall back to `landing_page`.

Tested: manually with 
- relative path
- absolute path
- file not found
- neither `landing_page_file` or `landing_page` set

Issue #52 also talks aboutrefactoring and changing the example html landing_page, thus I am not sure whether this PR should close that issue.