### PR TITLE
feat(server): add random suffix mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Here you can read the blog post about how it is deployed on Shuttle: [https://bl
   - random file names (optional)
     - pet name (e.g. `capital-mosquito.txt`)
     - alphanumeric string (e.g. `yB84D2Dv.txt`)
+    - random suffix (e.g. `file.MRV5as.tar.gz`)
   - supports expiring links
     - auto-expiration of files (optional)
     - auto-deletion of expired files (optional)
@@ -191,7 +192,6 @@ supported units:
 - `weeks`, `week`, `w`
 - `months`, `month`, `M`
 - `years`, `year`, `y`
-
 
 #### One shot files
 

--- a/config.toml
+++ b/config.toml
@@ -36,7 +36,7 @@ landing_page_content_type = "text/plain; charset=utf-8"
 [paste]
 random_url = { enabled = true, type = "petname", words = 2, separator = "-" }
 #random_url = { enabled = true, type = "alphanumeric", length = 8 }
-#random_url = { enabled = true, type = "alphanumeric", length = 6, random_suffix = true }
+#random_url = { enabled = true, type = "alphanumeric", length = 6, suffix_mode = true }
 default_extension = "txt"
 mime_override = [
   { mime = "image/jpeg", regex = "^.*\\.jpg$" },

--- a/config.toml
+++ b/config.toml
@@ -36,6 +36,7 @@ landing_page_content_type = "text/plain; charset=utf-8"
 [paste]
 random_url = { enabled = true, type = "petname", words = 2, separator = "-" }
 #random_url = { enabled = true, type = "alphanumeric", length = 8 }
+#random_url = { enabled = true, type = "alphanumeric", length = 6, random_suffix = true }
 default_extension = "txt"
 mime_override = [
   { mime = "image/jpeg", regex = "^.*\\.jpg$" },

--- a/fixtures/test-file-upload/config.toml
+++ b/fixtures/test-file-upload/config.toml
@@ -6,4 +6,4 @@ upload_path="./upload"
 [paste]
 random_url = { enabled = false, type = "petname", words = 2, separator = "-" }
 default_extension = "txt"
-duplicate_files = false
+duplicate_files = true

--- a/fixtures/test-file-upload/test.sh
+++ b/fixtures/test-file-upload/test.sh
@@ -4,6 +4,7 @@ content="test data"
 
 setup() {
   echo "$content" > file
+  echo "$content" > .file
 }
 
 run_test() {
@@ -11,9 +12,11 @@ run_test() {
   test "$file_url" = "http://localhost:8000/file.txt"
   test "$content" = "$(cat upload/file.txt)"
   test "$content" = "$(curl -s $file_url)"
+  file_url2=$(curl -s -F "file=@.file" localhost:8000)
+  test "$file_url2" = "http://localhost:8000/.file.txt"
 }
 
 teardown() {
-  rm file
+  rm file .file
   rm -r upload
 }

--- a/fixtures/test-random-suffix/config.toml
+++ b/fixtures/test-random-suffix/config.toml
@@ -4,6 +4,6 @@ max_content_length = "10MB"
 upload_path = "./upload"
 
 [paste]
-random_url = { enabled = true, type = "alphanumeric", length = "6", random_suffix = true }
+random_url = { enabled = true, type = "alphanumeric", length = "6", suffix_mode = true }
 default_extension = "txt"
 duplicate_files = true

--- a/fixtures/test-random-suffix/config.toml
+++ b/fixtures/test-random-suffix/config.toml
@@ -1,0 +1,9 @@
+[server]
+address = "127.0.0.1:8000"
+max_content_length = "10MB"
+upload_path = "./upload"
+
+[paste]
+random_url = { enabled = true, type = "alphanumeric", length = "6", random_suffix = true }
+default_extension = "txt"
+duplicate_files = true

--- a/fixtures/test-random-suffix/test.sh
+++ b/fixtures/test-random-suffix/test.sh
@@ -3,27 +3,27 @@
 content="test data"
 
 setup() {
-	echo "$content" >file
+  echo "$content" >file
 }
 
 run_test() {
-	first_file_url=$(curl -s -F "file=@file" localhost:8000)
-	test "$first_file_url" != "http://localhost:8000/file.txt"
-	test "$content" = "$(curl -s $first_file_url)"
+  first_file_url=$(curl -s -F "file=@file" localhost:8000)
+  test "$first_file_url" != "http://localhost:8000/file.txt"
+  test "$content" = "$(curl -s $first_file_url)"
 
-	second_file_url=$(curl -s -F "file=@file" localhost:8000)
-	test "$first_file_url" != "http://localhost:8000/file.txt"
-	test "$content" = "$(curl -s $first_file_url)"
+  second_file_url=$(curl -s -F "file=@file" localhost:8000)
+  test "$first_file_url" != "http://localhost:8000/file.txt"
+  test "$content" = "$(curl -s $first_file_url)"
 
-	test "$first_file_url" != "$second_file_url"
+  test "$first_file_url" != "$second_file_url"
 
-	test "$(cat upload/${first_file_url/http:\/\/localhost:8000\//})" \
-		= "$(cat upload/${second_file_url/http:\/\/localhost:8000\//})"
+  test "$(cat upload/${first_file_url/http:\/\/localhost:8000\//})" \
+    = "$(cat upload/${second_file_url/http:\/\/localhost:8000\//})"
 
-	[[ $(find upload/ -name "file.*.txt" -print -quit 2>/dev/null) ]] || exit 1
+  [[ $(find upload/ -name "file.*.txt" -print -quit 2>/dev/null) ]] || exit 1
 }
 
 teardown() {
-	rm file
-	rm -r upload
+  rm file
+  rm -r upload
 }

--- a/fixtures/test-random-suffix/test.sh
+++ b/fixtures/test-random-suffix/test.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+content="test data"
+
+setup() {
+	echo "$content" >file
+}
+
+run_test() {
+	first_file_url=$(curl -s -F "file=@file" localhost:8000)
+	test "$first_file_url" != "http://localhost:8000/file.txt"
+	test "$content" = "$(curl -s $first_file_url)"
+
+	second_file_url=$(curl -s -F "file=@file" localhost:8000)
+	test "$first_file_url" != "http://localhost:8000/file.txt"
+	test "$content" = "$(curl -s $first_file_url)"
+
+	test "$first_file_url" != "$second_file_url"
+
+	test "$(cat upload/${first_file_url/http:\/\/localhost:8000\//})" \
+		= "$(cat upload/${second_file_url/http:\/\/localhost:8000\//})"
+
+	[[ $(find upload/ -name "file.*.txt" -print -quit 2>/dev/null) ]] || exit 1
+}
+
+teardown() {
+	rm file
+	rm -r upload
+}

--- a/src/paste.rs
+++ b/src/paste.rs
@@ -125,27 +125,28 @@ impl Paste {
 
         // set_file_name does not accept names that contain a . unless it is the first character (e.g. "file.name" not ok, ".file" ok)
         // as a workaround we use set_extension, because it can set multiple extensions (e.g. "tar.gz")
+        // never accept a filename "." - similar to above where an empty string is replaced by file, and - by stdin
         if input == "." {
             input = "file".to_string();
         }
-
+        // Split the string into an array
         let mut v: Vec<&str> = input.split('.').collect();
-
         let mut filename;
         let mut dotfile = false;
-        let first = v[0];
-        if !first.is_empty() {
+        if !v[0].is_empty() {
             filename = v[0].to_string();
         } else {
+            // If the first array element is empty, it means the file started with a dot (e.g.: .foo)
             filename = format!(".{}", v[1]);
+            // Index shifts one to the right in the array for the rest of the string (the extension)
             dotfile = true;
         }
-
         let mut extension;
-        let l = v.len();
-        if l > 1 {
+        if v.len() > 1 {
+            // To get the rest (the extension), we have to remove the first element of the array, which is the filename
             v.remove(0);
             if dotfile {
+                // If the filename starts with a dot, we have to remove another element, because the first element was empty
                 v.remove(0);
             }
             extension = v.join(".");

--- a/src/paste.rs
+++ b/src/paste.rs
@@ -158,8 +158,8 @@ impl Paste {
         }
 
         if let Some(random_text) = config.paste.random_url.generate() {
-            if let Some(suffix_mode) = config.paste.random_url.suffix_mode {
-                if suffix_mode {
+            if let Some(random_suffix) = config.paste.random_url.random_suffix {
+                if random_suffix {
                     extension = format!("{}.{}", random_text, extension);
                 } else {
                     filename = random_text;
@@ -312,7 +312,7 @@ mod tests {
             enabled: true,
             length: Some(4),
             type_: RandomURLType::Alphanumeric,
-            suffix_mode: Some(true),
+            random_suffix: Some(true),
             ..RandomURLConfig::default()
         };
         let paste = Paste {
@@ -329,7 +329,7 @@ mod tests {
             enabled: true,
             length: Some(4),
             type_: RandomURLType::Alphanumeric,
-            suffix_mode: Some(true),
+            random_suffix: Some(true),
             ..RandomURLConfig::default()
         };
         let paste = Paste {
@@ -346,7 +346,7 @@ mod tests {
             enabled: true,
             length: Some(4),
             type_: RandomURLType::Alphanumeric,
-            suffix_mode: Some(false),
+            random_suffix: Some(false),
             ..RandomURLConfig::default()
         };
         let paste = Paste {

--- a/src/paste.rs
+++ b/src/paste.rs
@@ -307,6 +307,23 @@ mod tests {
         );
         fs::remove_file(file_name)?;
 
+        config.paste.random_url = RandomURLConfig {
+            enabled: true,
+            length: Some(4),
+            type_: RandomURLType::Alphanumeric,
+            suffix_mode: Some(true),
+            ..RandomURLConfig::default()
+        };
+        let paste = Paste {
+            data: vec![116, 101, 115, 115, 117, 115],
+            type_: PasteType::File,
+        };
+        let file_name = paste.store_file("foo.tar.gz", None, &config)?;
+        assert_eq!("tessus", fs::read_to_string(&file_name)?);
+        assert_eq!(true, file_name.ends_with(".tar.gz"));
+        assert_eq!(true, file_name.starts_with("foo."));
+        fs::remove_file(file_name)?;
+
         config.paste.default_extension = String::from("bin");
         config.paste.random_url.enabled = false;
         config.paste.random_url = RandomURLConfig {

--- a/src/paste.rs
+++ b/src/paste.rs
@@ -320,8 +320,8 @@ mod tests {
         };
         let file_name = paste.store_file("foo.tar.gz", None, &config)?;
         assert_eq!("tessus", fs::read_to_string(&file_name)?);
-        assert_eq!(true, file_name.ends_with(".tar.gz"));
-        assert_eq!(true, file_name.starts_with("foo."));
+        assert!(file_name.ends_with(".tar.gz"));
+        assert!(file_name.starts_with("foo."));
         fs::remove_file(file_name)?;
 
         config.paste.default_extension = String::from("bin");

--- a/src/paste.rs
+++ b/src/paste.rs
@@ -127,7 +127,8 @@ impl Paste {
         let mut file_name = match parts[0] {
             "" => {
                 // Index shifts one to the right in the array for the rest of the string (the extension)
-                dotfile = true; lower_bound = 2;
+                dotfile = true;
+                lower_bound = 2;
                 // If the first array element is empty, it means the file started with a dot (e.g.: .foo)
                 format!(".{}", parts[1])
             }

--- a/src/paste.rs
+++ b/src/paste.rs
@@ -147,8 +147,8 @@ impl Paste {
                 .to_string()
         };
         if let Some(random_text) = config.paste.random_url.generate() {
-            if let Some(random_suffix) = config.paste.random_url.random_suffix {
-                if random_suffix {
+            if let Some(suffix_mode) = config.paste.random_url.suffix_mode {
+                if suffix_mode {
                     extension = format!("{}.{}", random_text, extension);
                 } else {
                     file_name = random_text;
@@ -299,7 +299,7 @@ mod tests {
             enabled: true,
             length: Some(4),
             type_: RandomURLType::Alphanumeric,
-            random_suffix: Some(true),
+            suffix_mode: Some(true),
             ..RandomURLConfig::default()
         };
         let paste = Paste {
@@ -316,7 +316,7 @@ mod tests {
             enabled: true,
             length: Some(4),
             type_: RandomURLType::Alphanumeric,
-            random_suffix: Some(true),
+            suffix_mode: Some(true),
             ..RandomURLConfig::default()
         };
         let paste = Paste {
@@ -333,7 +333,7 @@ mod tests {
             enabled: true,
             length: Some(4),
             type_: RandomURLType::Alphanumeric,
-            random_suffix: Some(false),
+            suffix_mode: Some(false),
             ..RandomURLConfig::default()
         };
         let paste = Paste {

--- a/src/paste.rs
+++ b/src/paste.rs
@@ -129,7 +129,7 @@ impl Paste {
             input = "file".to_string();
         }
 
-        let mut v: Vec<&str> = input.split(".").collect();
+        let mut v: Vec<&str> = input.split('.').collect();
 
         let mut filename;
         let mut dotfile = false;
@@ -137,7 +137,7 @@ impl Paste {
         if !first.is_empty() {
             filename = v[0].to_string();
         } else {
-            filename = format!(".{}", v[1].to_string());
+            filename = format!(".{}", v[1]);
             dotfile = true;
         }
 

--- a/src/paste.rs
+++ b/src/paste.rs
@@ -325,6 +325,39 @@ mod tests {
         assert!(file_name.starts_with("foo."));
         fs::remove_file(file_name)?;
 
+        config.paste.random_url = RandomURLConfig {
+            enabled: true,
+            length: Some(4),
+            type_: RandomURLType::Alphanumeric,
+            suffix_mode: Some(true),
+            ..RandomURLConfig::default()
+        };
+        let paste = Paste {
+            data: vec![116, 101, 115, 115, 117, 115],
+            type_: PasteType::File,
+        };
+        let file_name = paste.store_file(".foo.tar.gz", None, &config)?;
+        assert_eq!("tessus", fs::read_to_string(&file_name)?);
+        assert!(file_name.ends_with(".tar.gz"));
+        assert!(file_name.starts_with(".foo."));
+        fs::remove_file(file_name)?;
+
+        config.paste.random_url = RandomURLConfig {
+            enabled: true,
+            length: Some(4),
+            type_: RandomURLType::Alphanumeric,
+            suffix_mode: Some(false),
+            ..RandomURLConfig::default()
+        };
+        let paste = Paste {
+            data: vec![116, 101, 115, 115, 117, 115],
+            type_: PasteType::File,
+        };
+        let file_name = paste.store_file("foo.tar.gz", None, &config)?;
+        assert_eq!("tessus", fs::read_to_string(&file_name)?);
+        assert!(file_name.ends_with(".tar.gz"));
+        fs::remove_file(file_name)?;
+
         config.paste.default_extension = String::from("bin");
         config.paste.random_url.enabled = false;
         config.paste.random_url = RandomURLConfig {

--- a/src/paste.rs
+++ b/src/paste.rs
@@ -123,16 +123,17 @@ impl Paste {
             .join(&file_name);
         let mut parts: Vec<&str> = file_name.split('.').collect();
         let mut dotfile = false;
+        let mut lower_bound = 1;
         let mut file_name = match parts[0] {
             "" => {
                 // Index shifts one to the right in the array for the rest of the string (the extension)
-                dotfile = true;
+                dotfile = true; lower_bound = 2;
                 // If the first array element is empty, it means the file started with a dot (e.g.: .foo)
                 format!(".{}", parts[1])
             }
             _ => parts[0].to_string(),
         };
-        let mut extension = if parts.len() > 1 {
+        let mut extension = if parts.len() > lower_bound {
             // To get the rest (the extension), we have to remove the first element of the array, which is the filename
             parts.remove(0);
             if dotfile {
@@ -343,6 +344,17 @@ mod tests {
         let file_name = paste.store_file("foo.tar.gz", None, &config)?;
         assert_eq!("tessus", fs::read_to_string(&file_name)?);
         assert!(file_name.ends_with(".tar.gz"));
+        fs::remove_file(file_name)?;
+
+        config.paste.default_extension = String::from("txt");
+        config.paste.random_url.enabled = false;
+        let paste = Paste {
+            data: vec![120, 121, 122],
+            type_: PasteType::File,
+        };
+        let file_name = paste.store_file(".foo", None, &config)?;
+        assert_eq!("xyz", fs::read_to_string(&file_name)?);
+        assert_eq!(".foo.txt", file_name);
         fs::remove_file(file_name)?;
 
         config.paste.default_extension = String::from("bin");

--- a/src/random.rs
+++ b/src/random.rs
@@ -15,7 +15,7 @@ pub struct RandomURLConfig {
     #[serde(rename = "type")]
     pub type_: RandomURLType,
     /// Append a random string to the original filename.
-    pub random_suffix: Option<bool>,
+    pub suffix_mode: Option<bool>,
 }
 
 impl RandomURLConfig {

--- a/src/random.rs
+++ b/src/random.rs
@@ -14,6 +14,8 @@ pub struct RandomURLConfig {
     /// Type of the random URL.
     #[serde(rename = "type")]
     pub type_: RandomURLType,
+    /// Suffix mode: append the random string to the original filename
+    pub suffix_mode: Option<bool>,
 }
 
 impl RandomURLConfig {

--- a/src/random.rs
+++ b/src/random.rs
@@ -14,8 +14,8 @@ pub struct RandomURLConfig {
     /// Type of the random URL.
     #[serde(rename = "type")]
     pub type_: RandomURLType,
-    /// Suffix mode: append the random string to the original filename
-    pub suffix_mode: Option<bool>,
+    /// Append a random string to the original filename.
+    pub random_suffix: Option<bool>,
 }
 
 impl RandomURLConfig {


### PR DESCRIPTION
Unfortunately the current implementation does not retain multiple extensions. So if you upload `foo.tar.gz`, the resulting file will be `eu7f92x1.gz`.

This PR includes 2 changes:

- multiple extensions are retained (e.g. `eu7f92x1.tar.gz`)
- added an optional option `suffix_mode` (bool) to `random_url` (result: `foo.eu7f92x1.tar.gz`)

closes #41 