### PR TITLE
style(server): add new line character to 404 message

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -99,7 +99,7 @@ async fn serve(
         }
     }
     if !path.is_file() || !path.exists() {
-        return Err(error::ErrorNotFound("file is not found or expired :("));
+        return Err(error::ErrorNotFound("file is not found or expired :(\n"));
     }
     match paste_type {
         PasteType::File | PasteType::RemoteFile | PasteType::Oneshot => {


### PR DESCRIPTION
I noticed a little missing new line character after I ran command for testing how rustypaste works:
`curl http://localhost:8000/sweeping-tahr`
After that, server side returns:
`file is not found or expired :(` without new line character and terminal output looks bad.
 