### PR TITLE
feat(server): support multiple auth tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ $ curl -F "remote=https://example.com/file.png" "<server_address>"
 
 #### Cleaning up expired files
 
-Configure `delete_expired_files` to set an interval for deleting the expired files automatically.
+Configure `[paste].delete_expired_files` to set an interval for deleting the expired files automatically.
 
 On the other hand, following script can be used as [cron](https://en.wikipedia.org/wiki/Cron) for cleaning up the expired files manually:
 
@@ -253,14 +253,16 @@ $ echo "AUTH_TOKEN=$(openssl rand -base64 16)" > .env
 $ rustypaste
 ```
 
+You can also set multiple auth tokens via the array field `[server].auth_tokens` in your `config.toml`.
+
 See [config.toml](./config.toml) for configuration options.
 
 #### HTML Form
 
 It is possible to use an HTML form for uploading files. To do so, you need to update two fields in your `config.toml`:
 
-- Set the `landing_page_content_type` to `text/html; charset=utf-8`.
-- Update the `landing_page` field with your HTML form.
+- Set the `[landing_page].content_type` to `text/html; charset=utf-8`.
+- Update the `[landing_page].text` field with your HTML form or point `[landing_page].file` to your html file.
 
 For an example, see [examples/html_form.toml](./examples/html_form.toml)
 

--- a/config.toml
+++ b/config.toml
@@ -9,6 +9,10 @@ max_content_length = "10MB"
 upload_path = "./upload"
 timeout = "30s"
 expose_version = false
+#auth_tokens = [
+#  "super_secret_token1",
+#  "super_secret_token2",
+#]
 
 [landing_page]
 text = """

--- a/fixtures/test-server-auth-multiple-tokens/config.toml
+++ b/fixtures/test-server-auth-multiple-tokens/config.toml
@@ -1,0 +1,10 @@
+[server]
+address="127.0.0.1:8000"
+max_content_length="10MB"
+upload_path="./upload"
+auth_tokens=["token1", "token2", "rustypasteisawesome", "token4"]
+
+[paste]
+random_url = { enabled = false, type = "petname", words = 2, separator = "-" }
+default_extension = "txt"
+duplicate_files = false

--- a/fixtures/test-server-auth-multiple-tokens/test.sh
+++ b/fixtures/test-server-auth-multiple-tokens/test.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-auth_tokens="rustypasteisawesome token1 token2 token4"
+auth_tokens=("rustypasteisawesome token1 token2 token4")
 
 content="topsecret"
 
@@ -12,7 +12,7 @@ run_test() {
   result=$(curl -s -F "file=@file" localhost:8000)
   test "unauthorized" = "$result"
 
-  for auth_token in $auth_tokens
+  for auth_token in ${auth_tokens[@]}
   do
     result=$(curl -s -F "file=@file" -H "Authorization: $auth_token" localhost:8000)
     test "unauthorized" != "$result"

--- a/fixtures/test-server-auth-multiple-tokens/test.sh
+++ b/fixtures/test-server-auth-multiple-tokens/test.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+auth_token="rustypasteisawesome"
+content="topsecret"
+
+setup() {
+  echo "$content" > file
+}
+
+run_test() {
+  result=$(curl -s -F "file=@file" localhost:8000)
+  test "unauthorized" = "$result"
+
+  result=$(curl -s -F "file=@file" -H "Authorization: $auth_token" localhost:8000)
+  test "unauthorized" != "$result"
+  test "$content" = "$(cat upload/file.txt)"
+  test "$content" = "$(curl -s $result)"
+}
+
+teardown() {
+  rm file
+  rm -r upload
+}

--- a/fixtures/test-server-auth-multiple-tokens/test.sh
+++ b/fixtures/test-server-auth-multiple-tokens/test.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-auth_tokens=("rustypasteisawesome token1 token2 token4")
+auth_tokens=("rustypasteisawesome" "token1" "token2" "token4")
 
 content="topsecret"
 

--- a/fixtures/test-server-auth-multiple-tokens/test.sh
+++ b/fixtures/test-server-auth-multiple-tokens/test.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
-auth_token="rustypasteisawesome"
+auth_tokens="rustypasteisawesome token1 token2 token4"
+
 content="topsecret"
 
 setup() {
@@ -11,10 +12,13 @@ run_test() {
   result=$(curl -s -F "file=@file" localhost:8000)
   test "unauthorized" = "$result"
 
-  result=$(curl -s -F "file=@file" -H "Authorization: $auth_token" localhost:8000)
-  test "unauthorized" != "$result"
-  test "$content" = "$(cat upload/file.txt)"
-  test "$content" = "$(curl -s $result)"
+  for auth_token in $auth_tokens
+  do
+    result=$(curl -s -F "file=@file" -H "Authorization: $auth_token" localhost:8000)
+    test "unauthorized" != "$result"
+    test "$content" = "$(cat upload/file.txt)"
+    test "$content" = "$(curl -s $result)"
+  done
 }
 
 teardown() {

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -5,23 +5,12 @@ use actix_web::{error, Error};
 ///
 /// `Authorization: (type) <token>`
 pub fn check(host: &str, headers: &HeaderMap, tokens: Option<Vec<String>>) -> Result<(), Error> {
-    if tokens.is_some() {
-        let mut token_found = false;
+    if let Some(tokens) = tokens {
         let auth_header = headers
             .get(AUTHORIZATION)
             .map(|v| v.to_str().unwrap_or_default())
             .map(|v| v.split_whitespace().last().unwrap_or_default());
-        if let Some(tokens) = tokens {
-            if !token_found {
-                for token in &tokens {
-                    if auth_header.unwrap_or_default() == token {
-                        token_found = true;
-                        break;
-                    }
-                }
-            }
-        }
-        if !token_found {
+        if !tokens.iter().any(|v| v == auth_header.unwrap_or_default()) {
             log::warn!(
                 "authorization failure for {} (header: {})",
                 host,

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -4,23 +4,13 @@ use actix_web::{error, Error};
 /// Checks the authorization header for the specified token.
 ///
 /// `Authorization: (type) <token>`
-pub fn check(
-    host: &str,
-    headers: &HeaderMap,
-    token: Option<String>,
-    tokens: Option<Vec<String>>,
-) -> Result<(), Error> {
-    if token.is_some() || tokens.is_some() {
+pub fn check(host: &str, headers: &HeaderMap, tokens: Option<Vec<String>>) -> Result<(), Error> {
+    if tokens.is_some() {
         let mut token_found = false;
         let auth_header = headers
             .get(AUTHORIZATION)
             .map(|v| v.to_str().unwrap_or_default())
             .map(|v| v.split_whitespace().last().unwrap_or_default());
-        if let Some(token) = token {
-            if !token.is_empty() && auth_header.unwrap_or_default() == token {
-                token_found = true;
-            }
-        }
         if let Some(tokens) = tokens {
             if !token_found {
                 for token in &tokens {
@@ -52,32 +42,23 @@ mod tests {
     fn test_check_auth() -> Result<(), Error> {
         let mut headers = HeaderMap::new();
         headers.insert(AUTHORIZATION, HeaderValue::from_static("basic test_token"));
-        assert!(check("", &headers, Some(String::from("test_token")), None).is_ok());
-        assert!(check("", &headers, Some(String::from("invalid_token")), None).is_err());
+        assert!(check("", &headers, Some(vec!["test_token".to_string()])).is_ok());
+        assert!(check("", &headers, Some(vec!["invalid_token".to_string()])).is_err());
         assert!(check(
             "",
             &headers,
-            None,
             Some(vec!["invalid1".to_string(), "test_token".to_string()])
         )
         .is_ok());
         assert!(check(
             "",
             &headers,
-            None,
             Some(vec!["invalid1".to_string(), "invalid2".to_string()])
         )
         .is_err());
-        assert!(check(
-            "",
-            &headers,
-            Some(String::from("invalid_token")),
-            Some(vec!["test_token".to_string(), "invalid2".to_string()])
-        )
-        .is_ok());
-        assert!(check("", &headers, None, None).is_ok());
-        assert!(check("", &HeaderMap::new(), None, None).is_ok());
-        assert!(check("", &HeaderMap::new(), Some(String::from("token")), None).is_err());
+        assert!(check("", &headers, None).is_ok());
+        assert!(check("", &HeaderMap::new(), None).is_ok());
+        assert!(check("", &HeaderMap::new(), Some(vec!["token".to_string()])).is_err());
         Ok(())
     }
 }

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -4,21 +4,40 @@ use actix_web::{error, Error};
 /// Checks the authorization header for the specified token.
 ///
 /// `Authorization: (type) <token>`
-pub fn check(host: &str, headers: &HeaderMap, token: Option<String>) -> Result<(), Error> {
-    if let Some(token) = token {
-        if !token.is_empty() {
-            let auth_header = headers
-                .get(AUTHORIZATION)
-                .map(|v| v.to_str().unwrap_or_default())
-                .map(|v| v.split_whitespace().last().unwrap_or_default());
-            if auth_header.unwrap_or_default() != token {
-                log::warn!(
-                    "authorization failure for {} (header: {})",
-                    host,
-                    auth_header.unwrap_or("none"),
-                );
-                return Err(error::ErrorUnauthorized("unauthorized"));
+pub fn check(
+    host: &str,
+    headers: &HeaderMap,
+    token: Option<String>,
+    tokens: Option<Vec<String>>,
+) -> Result<(), Error> {
+    if token.is_some() || tokens.is_some() {
+        let mut token_found = false;
+        let auth_header = headers
+            .get(AUTHORIZATION)
+            .map(|v| v.to_str().unwrap_or_default())
+            .map(|v| v.split_whitespace().last().unwrap_or_default());
+        if let Some(token) = token {
+            if !token.is_empty() && auth_header.unwrap_or_default() == token {
+                token_found = true;
             }
+        }
+        if let Some(tokens) = tokens {
+            if !token_found {
+                for token in &tokens {
+                    if auth_header.unwrap_or_default() == token {
+                        token_found = true;
+                        break;
+                    }
+                }
+            }
+        }
+        if !token_found {
+            log::warn!(
+                "authorization failure for {} (header: {})",
+                host,
+                auth_header.unwrap_or("none"),
+            );
+            return Err(error::ErrorUnauthorized("unauthorized"));
         }
     }
     Ok(())
@@ -33,11 +52,32 @@ mod tests {
     fn test_check_auth() -> Result<(), Error> {
         let mut headers = HeaderMap::new();
         headers.insert(AUTHORIZATION, HeaderValue::from_static("basic test_token"));
-        assert!(check("", &headers, Some(String::from("test_token"))).is_ok());
-        assert!(check("", &headers, Some(String::from("invalid_token"))).is_err());
-        assert!(check("", &headers, None).is_ok());
-        assert!(check("", &HeaderMap::new(), None).is_ok());
-        assert!(check("", &HeaderMap::new(), Some(String::from("token"))).is_err());
+        assert!(check("", &headers, Some(String::from("test_token")), None).is_ok());
+        assert!(check("", &headers, Some(String::from("invalid_token")), None).is_err());
+        assert!(check(
+            "",
+            &headers,
+            None,
+            Some(vec!["invalid1".to_string(), "test_token".to_string()])
+        )
+        .is_ok());
+        assert!(check(
+            "",
+            &headers,
+            None,
+            Some(vec!["invalid1".to_string(), "invalid2".to_string()])
+        )
+        .is_err());
+        assert!(check(
+            "",
+            &headers,
+            Some(String::from("invalid_token")),
+            Some(vec!["test_token".to_string(), "invalid2".to_string()])
+        )
+        .is_ok());
+        assert!(check("", &headers, None, None).is_ok());
+        assert!(check("", &HeaderMap::new(), None, None).is_ok());
+        assert!(check("", &HeaderMap::new(), Some(String::from("token")), None).is_err());
         Ok(())
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -44,6 +44,7 @@ pub struct ServerConfig {
     #[serde(default, with = "humantime_serde")]
     pub timeout: Option<Duration>,
     /// Authentication token.
+    #[deprecated(note = "use [server].auth_tokens instead")]
     pub auth_token: Option<String>,
     /// Authentication tokens.
     pub auth_tokens: Option<Vec<String>>,

--- a/src/config.rs
+++ b/src/config.rs
@@ -118,7 +118,6 @@ impl Config {
     pub fn get_tokens(&self) -> Option<Vec<String>> {
         let mut tokens = self.server.auth_tokens.clone().unwrap_or_default();
         if let Some(token) = &self.server.auth_token {
-            log::warn!("[server].auth_token is deprecated, please use [server].auth_tokens");
             tokens.insert(0, token.to_string());
         }
         if let Ok(env_token) = env::var(AUTH_TOKEN_ENV) {
@@ -127,7 +126,7 @@ impl Config {
         (!tokens.is_empty()).then_some(tokens)
     }
 
-    /// Print deprecation warnings (at server startup).
+    /// Print deprecation warnings.
     #[allow(deprecated)]
     pub fn warn_deprecation(&self) {
         if self.server.auth_token.is_some() {

--- a/src/config.rs
+++ b/src/config.rs
@@ -115,23 +115,15 @@ impl Config {
     /// Retrieves all configured tokens.
     #[allow(deprecated)]
     pub fn get_tokens(&self) -> Option<Vec<String>> {
-        if self.server.auth_token.is_some() || self.server.auth_tokens.is_some() {
-            let mut merged: Vec<String> = vec![];
-            if let Some(tokens) = &self.server.auth_tokens {
-                merged = tokens.clone();
-            }
-            if let Some(token) = &self.server.auth_token {
-                log::warn!("[server].auth_token is deprecated, please use [server].auth_tokens");
-                merged.insert(0, token.to_string());
-            }
-            if let Ok(env_token) = env::var(AUTH_TOKEN_ENV) {
-                merged.insert(0, env_token);
-            }
-            if !merged.is_empty() {
-                return Some(merged);
-            }
+        let mut tokens = self.server.auth_tokens.clone().unwrap_or_default();
+        if let Some(token) = &self.server.auth_token {
+            log::warn!("[server].auth_token is deprecated, please use [server].auth_tokens");
+            tokens.insert(0, token.to_string());
         }
-        None
+        if let Ok(env_token) = env::var(AUTH_TOKEN_ENV) {
+            tokens.insert(0, env_token);
+        }
+        (!tokens.is_empty()).then_some(tokens)
     }
     /// Print deprecation warnings (at server startup).
     #[allow(deprecated)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -112,6 +112,7 @@ impl Config {
             .build()?
             .try_deserialize()
     }
+
     /// Retrieves all configured tokens.
     #[allow(deprecated)]
     pub fn get_tokens(&self) -> Option<Vec<String>> {
@@ -125,6 +126,7 @@ impl Config {
         }
         (!tokens.is_empty()).then_some(tokens)
     }
+
     /// Print deprecation warnings (at server startup).
     #[allow(deprecated)]
     pub fn warn_deprecation(&self) {

--- a/src/config.rs
+++ b/src/config.rs
@@ -45,6 +45,8 @@ pub struct ServerConfig {
     pub timeout: Option<Duration>,
     /// Authentication token.
     pub auth_token: Option<String>,
+    /// Authentication tokens.
+    pub auth_tokens: Option<Vec<String>>,
     /// Expose version.
     pub expose_version: Option<bool>,
     /// Landing page text.

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,22 +24,6 @@ use {
     shuttle_actix_web::ShuttleActixWeb,
 };
 
-/// Print deprecation warnings at server startup
-#[allow(deprecated)]
-fn warn_deprecation(config: &Config) {
-    if config.server.auth_token.is_some() {
-        log::warn!("[server].auth_token is deprecated, please use [server].auth_tokens");
-    }
-    if config.server.landing_page.is_some() {
-        log::warn!("[server].landing_page is deprecated, please use [landing_page].text");
-    }
-    if config.server.landing_page_content_type.is_some() {
-        log::warn!(
-            "[server].landing_page_content_type is deprecated, please use [landing_page].content_type"
-        );
-    }
-}
-
 /// Sets up the application.
 ///
 /// * loads the configuration
@@ -64,7 +48,7 @@ fn setup(config_folder: &Path) -> IoResult<(Data<RwLock<Config>>, ServerConfig, 
     };
     let config = Config::parse(&config_path).expect("failed to parse config");
     log::trace!("{:#?}", config);
-    warn_deprecation(&config);
+    config.warn_deprecation();
     let server_config = config.server.clone();
     let paste_config = RwLock::new(config.paste.clone());
     let (config_sender, config_receiver) = mpsc::channel::<Config>();

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,6 +30,7 @@ use {
 /// * initializes the logger
 /// * creates the necessary directories
 /// * spawns the threads
+#[allow(deprecated)]
 fn setup(config_folder: &Path) -> IoResult<(Data<RwLock<Config>>, ServerConfig, Hotwatch)> {
     // Load the .env file.
     dotenvy::dotenv().ok();
@@ -48,6 +49,17 @@ fn setup(config_folder: &Path) -> IoResult<(Data<RwLock<Config>>, ServerConfig, 
     };
     let config = Config::parse(&config_path).expect("failed to parse config");
     log::trace!("{:#?}", config);
+    if config.server.auth_token.is_some() {
+        log::warn!("[server].auth_token is deprecated, please use [server].auth_tokens");
+    }
+    if config.server.landing_page.is_some() {
+        log::warn!("[server].landing_page is deprecated, please use [landing_page].text");
+    }
+    if config.server.landing_page_content_type.is_some() {
+        log::warn!(
+            "[server].landing_page_content_type is deprecated, please use [landing_page].content_type"
+        );
+    }
     let server_config = config.server.clone();
     let paste_config = RwLock::new(config.paste.clone());
     let (config_sender, config_receiver) = mpsc::channel::<Config>();

--- a/src/server.rs
+++ b/src/server.rs
@@ -165,6 +165,7 @@ async fn version(
         env::var(AUTH_TOKEN_ENV)
             .ok()
             .or_else(|| config.server.auth_token.as_ref().cloned()),
+        config.server.auth_tokens.as_ref().cloned(),
     )?;
     if !config.server.expose_version.unwrap_or(false) {
         log::warn!("server is not configured to expose version endpoint");
@@ -206,6 +207,13 @@ async fn upload(
             .auth_token
             .as_ref()
             .cloned()),
+        config
+            .read()
+            .map_err(|_| error::ErrorInternalServerError("cannot acquire config"))?
+            .server
+            .auth_tokens
+            .as_ref()
+            .cloned(),
     )?;
     let time = util::get_system_time()?;
     let mut expiry_date = header::parse_expiry_date(request.headers(), time)?;

--- a/src/server.rs
+++ b/src/server.rs
@@ -36,7 +36,6 @@ async fn index(config: web::Data<RwLock<Config>>) -> Result<HttpResponse, Error>
         if let Some(ref mut landing_page) = config.landing_page {
             landing_page.text = config.server.landing_page;
         }
-        log::warn!("[server].landing_page is deprecated, please use [landing_page].text");
     }
     if config.server.landing_page_content_type.is_some() {
         if config.landing_page.is_none() {
@@ -45,9 +44,6 @@ async fn index(config: web::Data<RwLock<Config>>) -> Result<HttpResponse, Error>
         if let Some(ref mut landing_page) = config.landing_page {
             landing_page.content_type = config.server.landing_page_content_type;
         }
-        log::warn!(
-                "[server].landing_page_content_type is deprecated, please use [landing_page].content_type"
-            );
     }
     if let Some(mut landing_page) = config.landing_page {
         if let Some(file) = landing_page.file {

--- a/src/server.rs
+++ b/src/server.rs
@@ -212,7 +212,7 @@ async fn upload(
                 .auth_token
                 .as_ref()
                 .cloned()
-            }),
+        }),
         config
             .read()
             .map_err(|_| error::ErrorInternalServerError("cannot acquire config"))?

--- a/src/server.rs
+++ b/src/server.rs
@@ -476,7 +476,7 @@ mod tests {
     #[actix_web::test]
     async fn test_version_without_auth() -> Result<(), Error> {
         let mut config = Config::default();
-        config.server.auth_token = Some(String::from("test"));
+        config.server.auth_tokens = Some(vec!["test".to_string()]);
         let app = test::init_service(
             App::new()
                 .app_data(Data::new(RwLock::new(config)))
@@ -540,7 +540,7 @@ mod tests {
     #[actix_web::test]
     async fn test_auth() -> Result<(), Error> {
         let mut config = Config::default();
-        config.server.auth_token = Some(String::from("test"));
+        config.server.auth_tokens = Some(vec!["test".to_string()]);
 
         let app = test::init_service(
             App::new()


### PR DESCRIPTION
## Description

This change supports the use of multiple authentication tokens.

Example:

```toml
[server]
auth_tokens = [
  "super_secret_token1",
  "super_secret_token2",
]
```

The previously used `AUTH_TOKEN` environment variable can still be used and will be evaluated as well.

## Motivation and Context

Allow to give people access to an otherwise private rustypaste instance.
see https://github.com/orhun/rustypaste/discussions/79

## How Has This Been Tested?

- test cases (cargo test)
- fixtures 
- manual testing on a Linux test VM

## Changelog Entry

````
### Added

- Add support for multiple auth tokens

Example:

```toml
[server]
auth_tokens = [
  "super_secret_token1",
  "super_secret_token2",
]
```

The previously used `AUTH_TOKEN` environment variable can still be used and will be evaluated as well.
````


## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
