### PR TITLE
chore(github): update the PR template about code blocks

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -21,12 +21,12 @@
 <!--- Follow the <https://keepachangelog.com/en/1.0.0/> format. -->
 <!--- Use one of the Added, Changed, Deprecated, Removed, Fixed, and Security headers accordingly. -->
 <!-- For example:
-```
+````
 ### Added
 
 - Add a middleware for checking the content length
   - Before, the upload size was checked after full upload which was clearly wrong.
-```
+````
 -->
 
 ## Types of Changes


### PR DESCRIPTION
## Description

When one wantes to use a code block in the changelog section it won't work, because it will end the previous block.
Adding another backtick solves the problem.

## Motivation and Context

see above

## How Has This Been Tested?

created this PR with the changed text.

## Changelog Entry

<!--- Please write the changelog entry for these changes. -->
<!--- Follow the <https://keepachangelog.com/en/1.0.0/> format. -->
<!--- Use one of the Added, Changed, Deprecated, Removed, Fixed, and Security headers accordingly. -->
<!-- For example:
````
### Changed

- Add another backtick to the code block in the Changelog Entry section
````
-->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [x] Other: PR template

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [ ] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [ ] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
