### PR TITLE
style(server): add new line char to most prominent messages

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -16,7 +16,7 @@ pub fn check(host: &str, headers: &HeaderMap, tokens: Option<Vec<String>>) -> Re
                 host,
                 auth_header.unwrap_or("none"),
             );
-            return Err(error::ErrorUnauthorized("unauthorized"));
+            return Err(error::ErrorUnauthorized("unauthorized\n"));
         }
     }
     Ok(())

--- a/src/server.rs
+++ b/src/server.rs
@@ -158,10 +158,10 @@ async fn version(
     auth::check(host, request.headers(), tokens)?;
     if !config.server.expose_version.unwrap_or(false) {
         log::warn!("server is not configured to expose version endpoint");
-        Err(error::ErrorForbidden("endpoint is not exposed"))?;
+        Err(error::ErrorForbidden("endpoint is not exposed\n"))?;
     }
     let version = env!("CARGO_PKG_VERSION");
-    Ok(HttpResponse::Ok().body(version))
+    Ok(HttpResponse::Ok().body(version.to_owned() + "\n"))
 }
 
 /// Handles file upload by processing `multipart/form-data`.
@@ -463,7 +463,7 @@ mod tests {
             .to_request();
         let response = test::call_service(&app, request).await;
         assert_eq!(StatusCode::UNAUTHORIZED, response.status());
-        assert_body(response.into_body(), "unauthorized").await?;
+        assert_body(response.into_body(), "unauthorized\n").await?;
         Ok(())
     }
 
@@ -483,7 +483,7 @@ mod tests {
             .to_request();
         let response = test::call_service(&app, request).await;
         assert_eq!(StatusCode::FORBIDDEN, response.status());
-        assert_body(response.into_body(), "endpoint is not exposed").await?;
+        assert_body(response.into_body(), "endpoint is not exposed\n").await?;
         Ok(())
     }
 
@@ -505,7 +505,11 @@ mod tests {
             .to_request();
         let response = test::call_service(&app, request).await;
         assert_eq!(StatusCode::OK, response.status());
-        assert_body(response.into_body(), env!("CARGO_PKG_VERSION")).await?;
+        assert_body(
+            response.into_body(),
+            &(env!("CARGO_PKG_VERSION").to_owned() + "\n"),
+        )
+        .await?;
         Ok(())
     }
 
@@ -525,7 +529,7 @@ mod tests {
         let response =
             test::call_service(&app, get_multipart_request("", "", "").to_request()).await;
         assert_eq!(StatusCode::UNAUTHORIZED, response.status());
-        assert_body(response.into_body(), "unauthorized").await?;
+        assert_body(response.into_body(), "unauthorized\n").await?;
 
         Ok(())
     }


### PR DESCRIPTION
<!--- Thank you for contributing to rustypaste! -->

## Description

This change adds a newline character to the most prominent messages. 

## Motivation and Context

This is a follow-up to #72 to make the output of the most prominent messages more consistent. 

Currently the output is not as legible as it could be:

```
[tessus@epsilon3 0 ~/data/tmp/rptest]$ curl https:/rptest.local/paste/version
unauthorized[tessus@epsilon3 0 ~/data/tmp/rptest]$ curl https:/rptest.local/paste/version -H "Authorization: token"
endpoint is not exposed[tessus@epsilon3 0 ~/data/tmp/rptest]$ curl https:/rptest.local/paste/not_available.txt
file is not found or expired :(
[tessus@epsilon3 0 ~/data/tmp/rptest]$ curl https:/rptest.local/paste/version -H "Authorization: token"
0.11.1[tessus@epsilon3 0 ~/data/tmp/rptest]$
```

Please note that I haven't added a new line character to all error messages, but only the ones that are encountered the most.

## How Has This Been Tested?

- cargo test
- fixtures
- manual testing

## Changelog Entry

<!--- Please write the changelog entry for these changes. -->
<!--- Follow the <https://keepachangelog.com/en/1.0.0/> format. -->
<!--- Use one of the Added, Changed, Deprecated, Removed, Fixed, and Security headers accordingly. -->

````
### Added

- Add new line character to most prominent messages
````


## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [x] Other: style of message output

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
