### PR TITLE
fix(server): do not list expired files

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -18,6 +18,7 @@ use std::env;
 use std::fs;
 use std::path::PathBuf;
 use std::sync::RwLock;
+use std::time::Duration;
 use uts2ts;
 
 /// Shows the landing page.
@@ -330,21 +331,29 @@ async fn list(
                     }
                 };
                 let mut file_name = PathBuf::from(e.file_name());
+                let mut exp_ext = 0;
                 let expires_at_utc = if let Some(expiration) = file_name
                     .extension()
                     .and_then(|ext| ext.to_str())
                     .and_then(|v| v.parse::<i64>().ok())
                 {
                     file_name.set_extension("");
+                    exp_ext = expiration;
                     Some(uts2ts::uts2ts(expiration / 1000).as_string())
                 } else {
                     None
                 };
-                Some(ListItem {
-                    file_name,
-                    file_size: metadata.len(),
-                    expires_at_utc,
-                })
+                if expires_at_utc.is_none()
+                    || (util::get_system_time().ok() < Some(Duration::from_millis(exp_ext as u64)))
+                {
+                    Some(ListItem {
+                        file_name,
+                        file_size: metadata.len(),
+                        expires_at_utc,
+                    })
+                } else {
+                    None
+                }
             })
         })
         .collect();


### PR DESCRIPTION
<!--- Thank you for contributing to rustypaste! -->

## Description

Expired files are also returned by the `/list` endpoint. This change only returns valid and accessible files.

## Motivation and Context

Fix above mentioned issue.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- autmated tests
- manual testing

## Changelog Entry

<!--- Please write the changelog entry for these changes. -->
<!--- Follow the <https://keepachangelog.com/en/1.0.0/> format. -->
<!--- Use one of the Added, Changed, Deprecated, Removed, Fixed, and Security headers accordingly. -->
````
### Fixed

- Do not list expired files
````

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
