### PR TITLE
fix(server): don't log invalid token in release builds

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -11,11 +11,14 @@ pub fn check(host: &str, headers: &HeaderMap, tokens: Option<Vec<String>>) -> Re
             .map(|v| v.to_str().unwrap_or_default())
             .map(|v| v.split_whitespace().last().unwrap_or_default());
         if !tokens.iter().any(|v| v == auth_header.unwrap_or_default()) {
+            #[cfg(debug_assertions)]
             log::warn!(
-                "authorization failure for {} (header: {})",
+                "authorization failure for {} (token: {})",
                 host,
                 auth_header.unwrap_or("none"),
             );
+            #[cfg(not(debug_assertions))]
+            log::warn!("authorization failure for {}", host);
             return Err(error::ErrorUnauthorized("unauthorized\n"));
         }
     }

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -13,12 +13,11 @@ pub fn check(host: &str, headers: &HeaderMap, tokens: Option<Vec<String>>) -> Re
         if !tokens.iter().any(|v| v == auth_header.unwrap_or_default()) {
             #[cfg(debug_assertions)]
             log::warn!(
-                "authorization failure for {} (token: {})",
-                host,
+                "authorization failure for {host} (token: {})",
                 auth_header.unwrap_or("none"),
             );
             #[cfg(not(debug_assertions))]
-            log::warn!("authorization failure for {}", host);
+            log::warn!("authorization failure for {host}");
             return Err(error::ErrorUnauthorized("unauthorized\n"));
         }
     }


### PR DESCRIPTION
<!--- Thank you for contributing to rustypaste! -->

## Description

The server logs a sent token, if the token is not valid:

e.g.: `rpaste -a invalid_token -V`

```
[2023-08-13T19:24:30Z WARN  rustypaste::auth] authorization failure for a.b.c.d (header: invalid_token)
```

This change prints the token only in debug mode. In release mode the log entry will look like this:

```
[2023-08-13T19:24:30Z WARN  rustypaste::auth] authorization failure for a.b.c.d
```

## Motivation and Context

fixes #111 

Let's say you use rpaste with the token in the config file (or curl with the auth_token as env var or in a file), but use different rustypaste servers. If you forget only once to add the `-a` flag (or add the header to curl), a production token for another instance will be logged.

## How Has This Been Tested?

- cargo test
- fixtures
- manual testing

## Changelog Entry

<!--- Please write the changelog entry for these changes. -->
<!--- Follow the <https://keepachangelog.com/en/1.0.0/> format. -->
<!--- Use one of the Added, Changed, Deprecated, Removed, Fixed, and Security headers accordingly. -->

````
### Fixed

- Don't log invalid token in release builds
````


## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
