### PR TITLE
chore(ci): replace unmaintained actions

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -24,11 +24,9 @@ jobs:
           sudo apt-get install -y --no-install-recommends \
             --allow-unauthenticated musl-tools
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
           target: ${{ matrix.TARGET }}
-          override: true
       - name: Build
         run: |
           cargo build --release --locked --target ${{ matrix.TARGET }}
@@ -61,8 +59,7 @@ jobs:
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v3
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
       - name: Publish
-        uses: actions-rs/cargo@v1
-        with:
-          command: publish
-          args: --locked --token ${{ secrets.CARGO_TOKEN }}
+        run: cargo publish --locked --token ${{ secrets.CARGO_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,31 +15,21 @@ jobs:
     name: Check
     runs-on: ubuntu-22.04
     steps:
-      - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
       - name: Checkout the repository
         uses: actions/checkout@v3
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
       - name: Check the project files
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --locked --verbose
+        run: cargo check --locked --verbose
 
   test:
     name: Test suite
     runs-on: ubuntu-22.04
     steps:
-      - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
       - name: Checkout the repository
         uses: actions/checkout@v3
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
       - name: Setup cargo-tarpaulin
         run: |
           curl -s https://api.github.com/repos/xd009642/tarpaulin/releases/latest | \
@@ -62,19 +52,12 @@ jobs:
     name: Test fixtures
     runs-on: ubuntu-22.04
     steps:
-      - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
       - name: Checkout the repository
         uses: actions/checkout@v3
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
       - name: Build the project
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --locked --verbose
+        run: cargo build --locked --verbose
       - name: Run test fixtures
         shell: bash
         run: ./test-fixtures.sh
@@ -86,39 +69,27 @@ jobs:
     name: Lints
     runs-on: ubuntu-22.04
     steps:
-      - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          components: clippy
-          override: true
       - name: Checkout the repository
         uses: actions/checkout@v3
-      - name: Check the lints
-        uses: actions-rs/cargo@v1
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
         with:
-          command: clippy
-          args: --tests --verbose -- -D warnings
+          components: clippy
+      - name: Check the lints
+        run: cargo clippy --tests --verbose -- -D warnings
 
   rustfmt:
     name: Formatting
     runs-on: ubuntu-22.04
     steps:
-      - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          components: rustfmt
-          override: true
       - name: Checkout the repository
         uses: actions/checkout@v3
-      - name: Check the formatting
-        uses: actions-rs/cargo@v1
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
         with:
-          command: fmt
-          args: -- --check --verbose
+          components: rustfmt
+      - name: Check the formatting
+        run: cargo fmt -- --check --verbose
 
   lychee:
     name: Links


### PR DESCRIPTION
<!--- Thank you for contributing to rustypaste! -->

## Description

This change replaces the unmaintained `action-rs/*` actions in the CI and CD workflows.

## Motivation and Context

Get rid of warnings that show up in the action workflows.

## How Has This Been Tested?

Manual testing in the forked rustypaste repo.

## Changelog Entry

<!--- Please write the changelog entry for these changes. -->
<!--- Follow the <https://keepachangelog.com/en/1.0.0/> format. -->
<!--- Use one of the Added, Changed, Deprecated, Removed, Fixed, and Security headers accordingly. -->

````
### Changed

- Replace unmaintained `action-rs/*` actions in the CI and CD workflows
````

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [x] Other : CI CD workflow

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [ ] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [ ] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
