### PR TITLE
feat(server): improve random_url config handling

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -42,9 +42,9 @@ Command line tool is available  at https://github.com/orhun/rustypaste-cli
 content_type = "text/plain; charset=utf-8"
 
 [paste]
-random_url = { enabled = true, type = "petname", words = 2, separator = "-" }
-#random_url = { enabled = true, type = "alphanumeric", length = 8 }
-#random_url = { enabled = true, type = "alphanumeric", length = 6, suffix_mode = true }
+random_url = { type = "petname", words = 2, separator = "-" }
+#random_url = { type = "alphanumeric", length = 8 }
+#random_url = { type = "alphanumeric", length = 6, suffix_mode = true }
 default_extension = "txt"
 mime_override = [
   { mime = "image/jpeg", regex = "^.*\\.jpg$" },

--- a/examples/html_form.toml
+++ b/examples/html_form.toml
@@ -15,8 +15,8 @@ file = "landing_page.html"
 content_type = "text/html; charset=utf-8"
 
 [paste]
-random_url = { enabled = true, type = "petname", words = 2, separator = "-" }
-#random_url = { enabled = true, type = "alphanumeric", length = 8 }
+random_url = { type = "petname", words = 2, separator = "-" }
+#random_url = { type = "alphanumeric", length = 8 }
 default_extension = "txt"
 mime_override = [
   { mime = "image/jpeg", regex = "^.*\\.jpg$" },

--- a/fixtures/test-duplicate-file-upload/config.toml
+++ b/fixtures/test-duplicate-file-upload/config.toml
@@ -1,9 +1,9 @@
 [server]
-address="127.0.0.1:8000"
-max_content_length="10MB"
-upload_path="./upload"
+address = "127.0.0.1:8000"
+max_content_length = "10MB"
+upload_path = "./upload"
 
 [paste]
-random_url = { enabled = true, type = "petname", words = 2, separator = "-" }
+random_url = { type = "petname", words = 2, separator = "-" }
 default_extension = "txt"
 duplicate_files = false

--- a/fixtures/test-expiring-file-upload/config.toml
+++ b/fixtures/test-expiring-file-upload/config.toml
@@ -1,9 +1,8 @@
 [server]
-address="127.0.0.1:8000"
-max_content_length="10MB"
-upload_path="./upload"
+address = "127.0.0.1:8000"
+max_content_length = "10MB"
+upload_path = "./upload"
 
 [paste]
-random_url = { enabled = false, type = "petname", words = 2, separator = "-" }
 default_extension = "txt"
 duplicate_files = false

--- a/fixtures/test-file-upload/config.toml
+++ b/fixtures/test-file-upload/config.toml
@@ -1,9 +1,8 @@
 [server]
-address="127.0.0.1:8000"
-max_content_length="10MB"
-upload_path="./upload"
+address = "127.0.0.1:8000"
+max_content_length = "10MB"
+upload_path = "./upload"
 
 [paste]
-random_url = { enabled = false, type = "petname", words = 2, separator = "-" }
 default_extension = "txt"
 duplicate_files = true

--- a/fixtures/test-list-files/config.toml
+++ b/fixtures/test-list-files/config.toml
@@ -6,6 +6,6 @@ auth_token = "rustypasteisawesome"
 expose_list = true
 
 [paste]
-random_url = { enabled = true, type = "petname", words = 2, separator = "-" }
+random_url = { type = "petname", words = 2, separator = "-" }
 default_extension = "txt"
 duplicate_files = true

--- a/fixtures/test-oneshot-upload/config.toml
+++ b/fixtures/test-oneshot-upload/config.toml
@@ -1,9 +1,8 @@
 [server]
-address="127.0.0.1:8000"
-max_content_length="10MB"
-upload_path="./upload"
+address = "127.0.0.1:8000"
+max_content_length = "10MB"
+upload_path = "./upload"
 
 [paste]
-random_url = { enabled = false, type = "petname", words = 2, separator = "-" }
 default_extension = "txt"
 duplicate_files = false

--- a/fixtures/test-oneshot-url/config.toml
+++ b/fixtures/test-oneshot-url/config.toml
@@ -1,9 +1,8 @@
 [server]
-address="127.0.0.1:8000"
-max_content_length="10MB"
-upload_path="./upload"
+address = "127.0.0.1:8000"
+max_content_length = "10MB"
+upload_path = "./upload"
 
 [paste]
-random_url = { enabled = false, type = "petname", words = 2, separator = "-" }
 default_extension = "txt"
 duplicate_files = false

--- a/fixtures/test-path-traversal/config.toml
+++ b/fixtures/test-path-traversal/config.toml
@@ -1,9 +1,8 @@
 [server]
-address="127.0.0.1:8000"
-max_content_length="10kb"
-upload_path="./upload"
+address = "127.0.0.1:8000"
+max_content_length = "10kb"
+upload_path = "./upload"
 
 [paste]
-random_url = { enabled = false, type = "petname", words = 2, separator = "-" }
 default_extension = "txt"
 duplicate_files = false

--- a/fixtures/test-random-suffix/config.toml
+++ b/fixtures/test-random-suffix/config.toml
@@ -4,6 +4,6 @@ max_content_length = "10MB"
 upload_path = "./upload"
 
 [paste]
-random_url = { enabled = true, type = "alphanumeric", length = "6", suffix_mode = true }
+random_url = { type = "alphanumeric", length = "6", suffix_mode = true }
 default_extension = "txt"
 duplicate_files = true

--- a/fixtures/test-random-url/config.toml
+++ b/fixtures/test-random-url/config.toml
@@ -1,9 +1,9 @@
 [server]
-address="127.0.0.1:8000"
-max_content_length="10MB"
-upload_path="./upload"
+address = "127.0.0.1:8000"
+max_content_length = "10MB"
+upload_path = "./upload"
 
 [paste]
-random_url = { enabled = true, type = "alphanumeric", length = "8" }
+random_url = { type = "alphanumeric", length = "8" }
 default_extension = "txt"
 duplicate_files = true

--- a/fixtures/test-remote-file-upload/config.toml
+++ b/fixtures/test-remote-file-upload/config.toml
@@ -1,10 +1,9 @@
 [server]
-address="127.0.0.1:8000"
-max_content_length="10MB"
-upload_path="./upload"
-timeout="60s"
+address = "127.0.0.1:8000"
+max_content_length = "10MB"
+upload_path = "./upload"
+timeout = "60s"
 
 [paste]
-random_url = { enabled = false, type = "petname", words = 2, separator = "-" }
 default_extension = "txt"
 duplicate_files = false

--- a/fixtures/test-server-auth-multiple-tokens/config.toml
+++ b/fixtures/test-server-auth-multiple-tokens/config.toml
@@ -1,10 +1,9 @@
 [server]
-address="127.0.0.1:8000"
-max_content_length="10MB"
-upload_path="./upload"
-auth_tokens=["token1", "token2", "rustypasteisawesome", "token4"]
+address = "127.0.0.1:8000"
+max_content_length = "10MB"
+upload_path = "./upload"
+auth_tokens = ["token1", "token2", "rustypasteisawesome", "token4"]
 
 [paste]
-random_url = { enabled = false, type = "petname", words = 2, separator = "-" }
 default_extension = "txt"
 duplicate_files = false

--- a/fixtures/test-server-auth/config.toml
+++ b/fixtures/test-server-auth/config.toml
@@ -1,10 +1,9 @@
 [server]
-address="127.0.0.1:8000"
-max_content_length="10MB"
-upload_path="./upload"
-auth_token="rustypasteisawesome"
+address = "127.0.0.1:8000"
+max_content_length = "10MB"
+upload_path = "./upload"
+auth_token = "rustypasteisawesome"
 
 [paste]
-random_url = { enabled = false, type = "petname", words = 2, separator = "-" }
 default_extension = "txt"
 duplicate_files = false

--- a/fixtures/test-server-auto-deletion/config.toml
+++ b/fixtures/test-server-auto-deletion/config.toml
@@ -1,10 +1,10 @@
 [server]
-address="127.0.0.1:8000"
-max_content_length="10MB"
-upload_path="./upload"
+address = "127.0.0.1:8000"
+max_content_length = "10MB"
+upload_path = "./upload"
 
 [paste]
-random_url = { enabled = true, type = "petname", words = 2, separator = "-" }
+random_url = { type = "petname", words = 2, separator = "-" }
 default_extension = "txt"
 duplicate_files = true
 delete_expired_files = { enabled = true, interval = "2s" }

--- a/fixtures/test-server-default-extension/config.toml
+++ b/fixtures/test-server-default-extension/config.toml
@@ -1,9 +1,8 @@
 [server]
-address="127.0.0.1:8000"
-max_content_length="10MB"
-upload_path="./upload"
+address = "127.0.0.1:8000"
+max_content_length = "10MB"
+upload_path = "./upload"
 
 [paste]
-random_url = { enabled = false, type = "petname", words = 2, separator = "-" }
 default_extension = "bin"
 duplicate_files = false

--- a/fixtures/test-server-landing-page-file/config.toml
+++ b/fixtures/test-server-landing-page-file/config.toml
@@ -1,14 +1,13 @@
 [server]
-address="127.0.0.1:8000"
-max_content_length="10MB"
-upload_path="./upload"
+address = "127.0.0.1:8000"
+max_content_length = "10MB"
+upload_path = "./upload"
 
 [landing_page]
-text="awesome_landing"
-file="page.txt"
+text = "awesome_landing"
+file = "page.txt"
 content_type = "text/plain; charset=utf-8"
 
 [paste]
-random_url = { enabled = false, type = "petname", words = 2, separator = "-" }
 default_extension = "txt"
 duplicate_files = false

--- a/fixtures/test-server-landing-page/config.toml
+++ b/fixtures/test-server-landing-page/config.toml
@@ -1,13 +1,12 @@
 [server]
-address="127.0.0.1:8000"
-max_content_length="10MB"
-upload_path="./upload"
+address = "127.0.0.1:8000"
+max_content_length = "10MB"
+upload_path = "./upload"
 
 [landing_page]
-text="awesome_landing"
+text = "awesome_landing"
 content_type = "text/plain; charset=utf-8"
 
 [paste]
-random_url = { enabled = false, type = "petname", words = 2, separator = "-" }
 default_extension = "txt"
 duplicate_files = false

--- a/fixtures/test-server-mime-blacklist/config.toml
+++ b/fixtures/test-server-mime-blacklist/config.toml
@@ -1,13 +1,10 @@
 [server]
-address="127.0.0.1:8000"
-max_content_length="10MB"
-upload_path="./upload"
+address = "127.0.0.1:8000"
+max_content_length = "10MB"
+upload_path = "./upload"
 
 [paste]
-random_url = { enabled = true, type = "petname", words = 2, separator = "-" }
+random_url = { type = "petname", words = 2, separator = "-" }
 default_extension = "txt"
 duplicate_files = true
-mime_blacklist = [
-    "text/html",
-    "text/xml",
-]
+mime_blacklist = ["text/html", "text/xml"]

--- a/fixtures/test-server-mime-override/config.toml
+++ b/fixtures/test-server-mime-override/config.toml
@@ -1,10 +1,10 @@
 [server]
-address="127.0.0.1:8000"
-max_content_length="10MB"
-upload_path="./upload"
+address = "127.0.0.1:8000"
+max_content_length = "10MB"
+upload_path = "./upload"
 
 [paste]
-random_url = { enabled = true, type = "petname", words = 2, separator = "-" }
+random_url = { type = "petname", words = 2, separator = "-" }
 default_extension = "txt"
 duplicate_files = true
 mime_override = [

--- a/fixtures/test-server-payload-limit/config.toml
+++ b/fixtures/test-server-payload-limit/config.toml
@@ -1,9 +1,8 @@
 [server]
-address="127.0.0.1:8000"
-max_content_length="10kb"
-upload_path="./upload"
+address = "127.0.0.1:8000"
+max_content_length = "10kb"
+upload_path = "./upload"
 
 [paste]
-random_url = { enabled = false, type = "petname", words = 2, separator = "-" }
 default_extension = "txt"
 duplicate_files = false

--- a/fixtures/test-url-upload/config.toml
+++ b/fixtures/test-url-upload/config.toml
@@ -1,9 +1,8 @@
 [server]
-address="127.0.0.1:8000"
-max_content_length="10MB"
-upload_path="./upload"
+address = "127.0.0.1:8000"
+max_content_length = "10MB"
+upload_path = "./upload"
 
 [paste]
-random_url = { enabled = false, type = "petname", words = 2, separator = "-" }
 default_extension = "txt"
 duplicate_files = false

--- a/shuttle/config.toml
+++ b/shuttle/config.toml
@@ -32,8 +32,8 @@ If you liked this, consider supporting me: https://donate.orhun.dev <3
 landing_page_content_type = "text/plain; charset=utf-8"
 
 [paste]
-# random_url = { enabled = true, type = "petname", words = 2, separator = "-" }
-random_url = { enabled = true, type = "alphanumeric", length = 6 }
+# random_url = { type = "petname", words = 2, separator = "-" }
+random_url = { type = "alphanumeric", length = 6 }
 default_extension = "txt"
 mime_override = [
   { mime = "image/jpeg", regex = "^.*\\.jpg$" },

--- a/src/config.rs
+++ b/src/config.rs
@@ -77,7 +77,7 @@ pub struct LandingPageConfig {
 #[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
 pub struct PasteConfig {
     /// Random URL configuration.
-    pub random_url: RandomURLConfig,
+    pub random_url: Option<RandomURLConfig>,
     /// Default file extension.
     pub default_extension: String,
     /// Media type override options.
@@ -141,6 +141,13 @@ impl Config {
             log::warn!(
                 "[server].landing_page_content_type is deprecated, please use [landing_page].content_type"
             );
+        }
+        if let Some(random_url) = &self.paste.random_url {
+            if random_url.enabled.is_some() {
+                log::warn!(
+                    "[paste].random_url.enabled is deprecated, to disable comment out [paste].random_url"
+                );
+            }
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -145,7 +145,7 @@ impl Config {
         if let Some(random_url) = &self.paste.random_url {
             if random_url.enabled.is_some() {
                 log::warn!(
-                    "[paste].random_url.enabled is deprecated, to disable comment out [paste].random_url"
+                    "[paste].random_url.enabled is deprecated, disable it by commenting out [paste].random_url"
                 );
             }
         }
@@ -165,6 +165,7 @@ mod tests {
         assert_eq!("0.0.1.1", config.server.address);
         Ok(())
     }
+
     #[test]
     #[allow(deprecated)]
     fn test_parse_deprecated_config() -> Result<(), ConfigError> {

--- a/src/config.rs
+++ b/src/config.rs
@@ -165,4 +165,18 @@ mod tests {
         assert_eq!("0.0.1.1", config.server.address);
         Ok(())
     }
+    #[test]
+    #[allow(deprecated)]
+    fn test_parse_deprecated_config() -> Result<(), ConfigError> {
+        let config_path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("config.toml");
+        env::set_var("SERVER__ADDRESS", "0.0.1.1");
+        let mut config = Config::parse(&config_path)?;
+        config.paste.random_url = Some(RandomURLConfig {
+            enabled: Some(true),
+            ..RandomURLConfig::default()
+        });
+        assert_eq!("0.0.1.1", config.server.address);
+        config.warn_deprecation();
+        Ok(())
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -84,6 +84,7 @@ fn setup(config_folder: &Path) -> IoResult<(Data<RwLock<Config>>, ServerConfig, 
                         if let Err(e) = config_sender.send(config) {
                             log::error!("Failed to send config for the cleanup routine: {}", e)
                         }
+                        cloned_config.warn_deprecation();
                     }
                     Err(e) => {
                         log::error!("Failed to acquire config: {}", e);

--- a/src/paste.rs
+++ b/src/paste.rs
@@ -259,7 +259,6 @@ impl Paste {
                 file_name = random_text;
             }
         }
-
         let mut path = self
             .type_
             .get_path(&config.server.upload_path)

--- a/src/paste.rs
+++ b/src/paste.rs
@@ -247,12 +247,6 @@ impl Paste {
         let data = str::from_utf8(&self.data)
             .map_err(|e| IoError::new(IoErrorKind::Other, e.to_string()))?;
         let url = Url::parse(data).map_err(|e| IoError::new(IoErrorKind::Other, e.to_string()))?;
-        //let mut file_name;
-        // let file_name = &config
-        //     .paste
-        //     .random_url
-        //     .generate()
-        //     .unwrap_or_else(|| self.type_.get_dir());
         let mut file_name = self.type_.get_dir();
         if let Some(random_url) = &config.paste.random_url {
             if let Some(random_text) = random_url.generate() {

--- a/src/paste.rs
+++ b/src/paste.rs
@@ -268,7 +268,7 @@ impl Paste {
             path.set_file_name(format!("{file_name}.{timestamp}"));
         }
         fs::write(&path, url.to_string())?;
-        Ok(file_name.to_string())
+        Ok(file_name)
     }
 }
 

--- a/src/paste.rs
+++ b/src/paste.rs
@@ -148,15 +148,17 @@ impl Paste {
                 .unwrap_or(&config.paste.default_extension)
                 .to_string()
         };
-        if let Some(random_text) = config.paste.random_url.generate() {
-            if let Some(suffix_mode) = config.paste.random_url.suffix_mode {
-                if suffix_mode {
-                    extension = format!("{}.{}", random_text, extension);
+        if let Some(random_url) = &config.paste.random_url {
+            if let Some(random_text) = random_url.generate() {
+                if let Some(suffix_mode) = random_url.suffix_mode {
+                    if suffix_mode {
+                        extension = format!("{}.{}", random_text, extension);
+                    } else {
+                        file_name = random_text;
+                    }
                 } else {
                     file_name = random_text;
                 }
-            } else {
-                file_name = random_text;
             }
         }
         path.set_file_name(file_name);
@@ -240,15 +242,24 @@ impl Paste {
     /// - If [`random_url.enabled`] is `true`, file name is set to a pet name or random string.
     ///
     /// [`random_url.enabled`]: crate::random::RandomURLConfig::enabled
+    #[allow(deprecated)]
     pub fn store_url(&self, expiry_date: Option<u128>, config: &Config) -> IoResult<String> {
         let data = str::from_utf8(&self.data)
             .map_err(|e| IoError::new(IoErrorKind::Other, e.to_string()))?;
         let url = Url::parse(data).map_err(|e| IoError::new(IoErrorKind::Other, e.to_string()))?;
-        let file_name = config
-            .paste
-            .random_url
-            .generate()
-            .unwrap_or_else(|| self.type_.get_dir());
+        //let mut file_name;
+        // let file_name = &config
+        //     .paste
+        //     .random_url
+        //     .generate()
+        //     .unwrap_or_else(|| self.type_.get_dir());
+        let mut file_name = self.type_.get_dir();
+        if let Some(random_url) = &config.paste.random_url {
+            if let Some(random_text) = random_url.generate() {
+                file_name = random_text;
+            }
+        }
+
         let mut path = self
             .type_
             .get_path(&config.server.upload_path)
@@ -257,7 +268,7 @@ impl Paste {
             path.set_file_name(format!("{file_name}.{timestamp}"));
         }
         fs::write(&path, url.to_string())?;
-        Ok(file_name)
+        Ok(file_name.to_string())
     }
 }
 
@@ -273,16 +284,17 @@ mod tests {
     use std::time::Duration;
 
     #[actix_rt::test]
+    #[allow(deprecated)]
     async fn test_paste_data() -> Result<(), Error> {
         let mut config = Config::default();
         config.server.upload_path = env::current_dir()?;
-        config.paste.random_url = RandomURLConfig {
-            enabled: true,
+        config.paste.random_url = Some(RandomURLConfig {
+            enabled: Some(true),
             words: Some(3),
             separator: Some(String::from("_")),
             type_: RandomURLType::PetName,
             ..RandomURLConfig::default()
-        };
+        });
         let paste = Paste {
             data: vec![65, 66, 67],
             type_: PasteType::File,
@@ -297,13 +309,12 @@ mod tests {
         );
         fs::remove_file(file_name)?;
 
-        config.paste.random_url = RandomURLConfig {
-            enabled: true,
+        config.paste.random_url = Some(RandomURLConfig {
             length: Some(4),
             type_: RandomURLType::Alphanumeric,
             suffix_mode: Some(true),
             ..RandomURLConfig::default()
-        };
+        });
         let paste = Paste {
             data: vec![116, 101, 115, 115, 117, 115],
             type_: PasteType::File,
@@ -314,13 +325,12 @@ mod tests {
         assert!(file_name.starts_with("foo."));
         fs::remove_file(file_name)?;
 
-        config.paste.random_url = RandomURLConfig {
-            enabled: true,
+        config.paste.random_url = Some(RandomURLConfig {
             length: Some(4),
             type_: RandomURLType::Alphanumeric,
             suffix_mode: Some(true),
             ..RandomURLConfig::default()
-        };
+        });
         let paste = Paste {
             data: vec![116, 101, 115, 115, 117, 115],
             type_: PasteType::File,
@@ -331,13 +341,12 @@ mod tests {
         assert!(file_name.starts_with(".foo."));
         fs::remove_file(file_name)?;
 
-        config.paste.random_url = RandomURLConfig {
-            enabled: true,
+        config.paste.random_url = Some(RandomURLConfig {
             length: Some(4),
             type_: RandomURLType::Alphanumeric,
             suffix_mode: Some(false),
             ..RandomURLConfig::default()
-        };
+        });
         let paste = Paste {
             data: vec![116, 101, 115, 115, 117, 115],
             type_: PasteType::File,
@@ -348,7 +357,7 @@ mod tests {
         fs::remove_file(file_name)?;
 
         config.paste.default_extension = String::from("txt");
-        config.paste.random_url.enabled = false;
+        config.paste.random_url = None;
         let paste = Paste {
             data: vec![120, 121, 122],
             type_: PasteType::File,
@@ -359,13 +368,11 @@ mod tests {
         fs::remove_file(file_name)?;
 
         config.paste.default_extension = String::from("bin");
-        config.paste.random_url.enabled = false;
-        config.paste.random_url = RandomURLConfig {
-            enabled: true,
+        config.paste.random_url = Some(RandomURLConfig {
             length: Some(10),
             type_: RandomURLType::Alphanumeric,
             ..RandomURLConfig::default()
-        };
+        });
         let paste = Paste {
             data: vec![120, 121, 122],
             type_: PasteType::File,
@@ -384,7 +391,7 @@ mod tests {
             fs::create_dir_all(paste_type.get_path(&config.server.upload_path))?;
         }
 
-        config.paste.random_url.enabled = false;
+        config.paste.random_url = None;
         let paste = Paste {
             data: vec![116, 101, 115, 116],
             type_: PasteType::Oneshot,
@@ -397,7 +404,10 @@ mod tests {
         assert_eq!("test", fs::read_to_string(&file_path)?);
         fs::remove_file(file_path)?;
 
-        config.paste.random_url.enabled = true;
+        config.paste.random_url = Some(RandomURLConfig {
+            enabled: Some(true),
+            ..RandomURLConfig::default()
+        });
         let url = String::from("https://orhun.dev/");
         let paste = Paste {
             data: url.as_bytes().to_vec(),

--- a/src/random.rs
+++ b/src/random.rs
@@ -4,7 +4,8 @@ use rand::{distributions::Alphanumeric, Rng};
 #[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
 pub struct RandomURLConfig {
     /// Use a random name instead of original file names.
-    pub enabled: bool,
+    #[deprecated(note = "disable by commenting out [paste].random_url")]
+    pub enabled: Option<bool>,
     /// Count of words that pet name will include.
     pub words: Option<u8>,
     /// Separator between the words.
@@ -18,24 +19,26 @@ pub struct RandomURLConfig {
     pub suffix_mode: Option<bool>,
 }
 
+#[allow(deprecated)]
 impl RandomURLConfig {
     /// Generates and returns a random URL (if `enabled`).
     pub fn generate(&self) -> Option<String> {
-        if self.enabled {
-            Some(match self.type_ {
-                RandomURLType::PetName => petname::petname(
-                    self.words.unwrap_or(2),
-                    self.separator.as_deref().unwrap_or("-"),
-                ),
-                RandomURLType::Alphanumeric => rand::thread_rng()
-                    .sample_iter(&Alphanumeric)
-                    .take(self.length.unwrap_or(8))
-                    .map(char::from)
-                    .collect::<String>(),
-            })
-        } else {
-            None
+        if let Some(enabled) = self.enabled {
+            if !enabled {
+                return None;
+            }
         }
+        Some(match self.type_ {
+            RandomURLType::PetName => petname::petname(
+                self.words.unwrap_or(2),
+                self.separator.as_deref().unwrap_or("-"),
+            ),
+            RandomURLType::Alphanumeric => rand::thread_rng()
+                .sample_iter(&Alphanumeric)
+                .take(self.length.unwrap_or(8))
+                .map(char::from)
+                .collect::<String>(),
+        })
     }
 }
 
@@ -59,10 +62,11 @@ impl Default for RandomURLType {
 mod tests {
     use super::*;
 
+    #[allow(deprecated)]
     #[test]
     fn test_generate_url() {
         let random_config = RandomURLConfig {
-            enabled: true,
+            enabled: Some(true),
             words: Some(3),
             separator: Some(String::from("~")),
             type_: RandomURLType::PetName,
@@ -74,7 +78,6 @@ mod tests {
         assert_eq!(3, random_url.split('~').count());
 
         let random_config = RandomURLConfig {
-            enabled: true,
             length: Some(21),
             type_: RandomURLType::Alphanumeric,
             ..RandomURLConfig::default()
@@ -85,7 +88,7 @@ mod tests {
         assert_eq!(21, random_url.len());
 
         let random_config = RandomURLConfig {
-            enabled: false,
+            enabled: Some(false),
             ..RandomURLConfig::default()
         };
         assert!(random_config.generate().is_none());

--- a/src/random.rs
+++ b/src/random.rs
@@ -23,10 +23,8 @@ pub struct RandomURLConfig {
 impl RandomURLConfig {
     /// Generates and returns a random URL (if `enabled`).
     pub fn generate(&self) -> Option<String> {
-        if let Some(enabled) = self.enabled {
-            if !enabled {
-                return None;
-            }
+        if !self.enabled.unwrap_or(true) {
+            return None;
         }
         Some(match self.type_ {
             RandomURLType::PetName => petname::petname(

--- a/src/server.rs
+++ b/src/server.rs
@@ -763,6 +763,7 @@ mod tests {
     }
 
     #[actix_web::test]
+    #[allow(deprecated)]
     async fn test_upload_duplicate_file() -> Result<(), Error> {
         let test_upload_dir = "test_upload";
         fs::create_dir(test_upload_dir)?;
@@ -770,11 +771,11 @@ mod tests {
         let mut config = Config::default();
         config.server.upload_path = PathBuf::from(&test_upload_dir);
         config.paste.duplicate_files = Some(false);
-        config.paste.random_url = RandomURLConfig {
-            enabled: true,
+        config.paste.random_url = Some(RandomURLConfig {
+            enabled: Some(true),
             type_: RandomURLType::Alphanumeric,
             ..Default::default()
-        };
+        });
 
         let app = test::init_service(
             App::new()


### PR DESCRIPTION
<!--- Thank you for contributing to rustypaste! -->

## Description

Currently, in order to turn random URL's off, you must have at least one `random_url` declaration with a type and enabled = `false`.

This PR makes the random_url config optional while deprecating the `enabled` field without breaking current configs.

## Motivation and Context

Closes #121

## How Has This Been Tested?

- cargo test
- fixtures
- manual

## Changelog Entry

<!--- Please write the changelog entry for these changes. -->
<!--- Follow the <https://keepachangelog.com/en/1.0.0/> format. -->
<!--- Use one of the Added, Changed, Deprecated, Removed, Fixed, and Security headers accordingly. -->

````
### Changed

- Make the `random_url` config optional

```toml
# enabled
random_url = { type = "petname", words = 2, separator = "-" }

# disabled 
# random_url = { type = "petname", words = 2, separator = "-" }
```

### Deprecated

- Deprecate `enabled` field in `random_url`
````

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
