### PR TITLE
feat(server): add delete endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,7 @@ Here you can read the blog post about how it is deployed on Shuttle: [https://bl
     - supports overriding and blacklisting
     - supports forcing to download via `?download=true`
   - no duplicate uploads (optional)
-  - listing files
-  - deleting files
+  - listing/deleting files
   - custom landing page
 - Single binary
   - [binary releases](https://github.com/orhun/rustypaste/releases)

--- a/README.md
+++ b/README.md
@@ -50,8 +50,9 @@ Here you can read the blog post about how it is deployed on Shuttle: [https://bl
     - [URL shortening](#url-shortening)
     - [Paste file from remote URL](#paste-file-from-remote-url)
     - [Cleaning up expired files](#cleaning-up-expired-files)
+    - [Delete file from server](#delete-file-from-server)
   - [Server](#server)
-  - [List endpoint](#list-endpoint)
+    - [List endpoint](#list-endpoint)
     - [HTML Form](#html-form)
     - [Docker](#docker)
     - [Nginx](#nginx)
@@ -79,6 +80,7 @@ Here you can read the blog post about how it is deployed on Shuttle: [https://bl
     - supports forcing to download via `?download=true`
   - no duplicate uploads (optional)
   - listing files
+  - deleting files
   - custom landing page
 - Single binary
   - [binary releases](https://github.com/orhun/rustypaste/releases)
@@ -235,6 +237,14 @@ while read -r filename; do
 done
 ```
 
+#### Delete file from server
+
+Set `delete_tokens` array in [config.toml](./config.toml) to activate the DELETE endpoint and secure it with one (or more) auth token(s).
+
+```sh
+$ curl -H "Authorization: <auth_token>" -X DELETE "<server_address>/file.txt"
+```
+
 ### Server
 
 To start the server:
@@ -260,7 +270,7 @@ You can also set multiple auth tokens via the array field `[server].auth_tokens`
 
 See [config.toml](./config.toml) for configuration options.
 
-### List endpoint
+#### List endpoint
 
 Set `expose_list` to true in [config.toml](./config.toml) to be able to retrieve a JSON formatted list of files in your uploads directory. This will not include oneshot files, oneshot URLs, or URLs.
 

--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ done
 
 #### Delete file from server
 
-Set `delete_tokens` array in [config.toml](./config.toml) to activate the DELETE endpoint and secure it with one (or more) auth token(s).
+Set `delete_tokens` array in [config.toml](./config.toml) to activate the [`DELETE`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/DELETE) endpoint and secure it with one (or more) auth token(s).
 
 ```sh
 $ curl -H "Authorization: <auth_token>" -X DELETE "<server_address>/file.txt"

--- a/config.toml
+++ b/config.toml
@@ -14,6 +14,10 @@ expose_list = false
 #  "super_secret_token1",
 #  "super_secret_token2",
 #]
+#delete_tokens = [
+#  "super_secret_token1",
+#  "super_secret_token3",
+#]
 handle_spaces = "replace" # or "encode"
 
 [landing_page]

--- a/fixtures/test-file-delete/config.toml
+++ b/fixtures/test-file-delete/config.toml
@@ -1,0 +1,9 @@
+[server]
+address = "127.0.0.1:8000"
+max_content_length = "10MB"
+upload_path = "./upload"
+delete_tokens = ["may_the_force_be_with_you"]
+
+[paste]
+default_extension = "txt"
+duplicate_files = true

--- a/fixtures/test-file-delete/test.sh
+++ b/fixtures/test-file-delete/test.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+content="test data"
+
+setup() {
+  echo "$content" > file
+}
+
+run_test() {
+  file_url=$(curl -s -F "file=@file" localhost:8000)
+  test "$file_url" = "http://localhost:8000/file.txt"
+  test "" = "$(curl -s -H "Authorization: may_the_force_be_with_you" -X DELETE http://localhost:8000/file.txt)"
+  test "file is not found or expired :(" = "$(curl -s -H "Authorization: may_the_force_be_with_you" -X DELETE http://localhost:8000/file.txt)"
+}
+
+teardown() {
+  rm file
+  rm -r upload
+}

--- a/fixtures/test-file-delete/test.sh
+++ b/fixtures/test-file-delete/test.sh
@@ -9,7 +9,7 @@ setup() {
 run_test() {
   file_url=$(curl -s -F "file=@file" localhost:8000)
   test "$file_url" = "http://localhost:8000/file.txt"
-  test "" = "$(curl -s -H "Authorization: may_the_force_be_with_you" -X DELETE http://localhost:8000/file.txt)"
+  test "the file is deleted" = "$(curl -s -H "Authorization: may_the_force_be_with_you" -X DELETE http://localhost:8000/file.txt)"
   test "file is not found or expired :(" = "$(curl -s -H "Authorization: may_the_force_be_with_you" -X DELETE http://localhost:8000/file.txt)"
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -237,17 +237,27 @@ mod tests {
     #[test]
     fn test_get_tokens() -> Result<(), ConfigError> {
         let config_path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("config.toml");
+        env::set_var("AUTH_TOKEN", "env_auth");
+        env::set_var("DELETE_TOKEN", "env_delete");
         let mut config = Config::parse(&config_path)?;
         config.server.auth_tokens = Some(vec!["may_the_force_be_with_you".to_string()]);
         config.server.delete_tokens = Some(vec!["i_am_your_father".to_string()]);
         assert_eq!(
-            Some(vec!["may_the_force_be_with_you".to_string()]),
+            Some(vec![
+                "env_auth".to_string(),
+                "may_the_force_be_with_you".to_string()
+            ]),
             config.get_tokens(TokenType::Auth)
         );
         assert_eq!(
-            Some(vec!["i_am_your_father".to_string()]),
+            Some(vec![
+                "env_delete".to_string(),
+                "i_am_your_father".to_string()
+            ]),
             config.get_tokens(TokenType::Delete)
         );
+        env::remove_var("AUTH_TOKEN");
+        env::remove_var("DELETE_TOKEN");
         Ok(())
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -152,10 +152,9 @@ impl Config {
         (!tokens.is_empty()).then_some(tokens)
     }
 
-    /// Retrieves all configured delete tokens
+    /// Retrieves all configured delete tokens.
     pub fn get_delete_tokens(&self) -> Option<Vec<String>> {
         let mut tokens = self.server.delete_tokens.clone().unwrap_or_default();
-
         if let Ok(env_token) = env::var(DELETE_TOKEN_ENV) {
             tokens.insert(0, env_token);
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -233,4 +233,21 @@ mod tests {
         let encoded_filename = SpaceHandlingConfig::Encode.process_filename("file with spaces.txt");
         assert_eq!("file%20with%20spaces.txt", encoded_filename);
     }
+
+    #[test]
+    fn test_get_tokens() -> Result<(), ConfigError> {
+        let config_path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("config.toml");
+        let mut config = Config::parse(&config_path)?;
+        config.server.auth_tokens = Some(vec!["may_the_force_be_with_you".to_string()]);
+        config.server.delete_tokens = Some(vec!["i_am_your_father".to_string()]);
+        assert_eq!(
+            Some(vec!["may_the_force_be_with_you".to_string()]),
+            config.get_tokens(TokenType::Auth)
+        );
+        assert_eq!(
+            Some(vec!["i_am_your_father".to_string()]),
+            config.get_tokens(TokenType::Delete)
+        );
+        Ok(())
+    }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -149,7 +149,7 @@ impl Config {
 
     /// Retrieves all configured auth/delete tokens.
     pub fn get_tokens(&self, token_type: TokenType) -> Option<Vec<String>> {
-        let tokens: Vec<String> = match token_type {
+        let mut tokens = match token_type {
             TokenType::Auth => {
                 let mut tokens = self.server.auth_tokens.clone().unwrap_or_default();
                 #[allow(deprecated)]
@@ -169,6 +169,7 @@ impl Config {
                 tokens
             }
         };
+        tokens.retain(|v| !v.is_empty());
         (!tokens.is_empty()).then_some(tokens)
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,6 @@
 use crate::mime::MimeMatcher;
 use crate::random::RandomURLConfig;
-use crate::AUTH_TOKEN_ENV;
+use crate::{AUTH_TOKEN_ENV, DELETE_TOKEN_ENV};
 use byte_unit::Byte;
 use config::{self, ConfigError};
 use std::env;
@@ -62,6 +62,8 @@ pub struct ServerConfig {
     pub handle_spaces: Option<SpaceHandlingConfig>,
     /// Path of the JSON index.
     pub expose_list: Option<bool>,
+    /// Authentication tokens for deleting.
+    pub delete_tokens: Option<Vec<String>>,
 }
 
 /// Enum representing different strategies for handling spaces in filenames.
@@ -137,14 +139,24 @@ impl Config {
             .try_deserialize()
     }
 
-    /// Retrieves all configured tokens.
+    /// Retrieves all configured auth tokens.
     #[allow(deprecated)]
-    pub fn get_tokens(&self) -> Option<Vec<String>> {
+    pub fn get_auth_tokens(&self) -> Option<Vec<String>> {
         let mut tokens = self.server.auth_tokens.clone().unwrap_or_default();
         if let Some(token) = &self.server.auth_token {
             tokens.insert(0, token.to_string());
         }
         if let Ok(env_token) = env::var(AUTH_TOKEN_ENV) {
+            tokens.insert(0, env_token);
+        }
+        (!tokens.is_empty()).then_some(tokens)
+    }
+
+    /// Retrieves all configured delete tokens
+    pub fn get_delete_tokens(&self) -> Option<Vec<String>> {
+        let mut tokens = self.server.delete_tokens.clone().unwrap_or_default();
+
+        if let Ok(env_token) = env::var(DELETE_TOKEN_ENV) {
             tokens.insert(0, env_token);
         }
         (!tokens.is_empty()).then_some(tokens)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,3 +36,6 @@ pub const CONFIG_ENV: &str = "CONFIG";
 
 /// Environment variable for setting the authentication token.
 pub const AUTH_TOKEN_ENV: &str = "AUTH_TOKEN";
+
+/// Environment variable for setting the deletion token.
+pub const DELETE_TOKEN_ENV: &str = "DELETE_TOKEN";

--- a/src/server.rs
+++ b/src/server.rs
@@ -162,7 +162,7 @@ async fn delete(
     let host = connection.realip_remote_addr().unwrap_or("unknown host");
     let tokens = config.get_tokens(TokenType::Delete);
     if tokens.is_none() {
-        log::warn!("delete endpoint not served because there are no delete_tokens set");
+        log::warn!("delete endpoint is not served because there are no delete_tokens set");
         return Err(error::ErrorForbidden("endpoint is not exposed\n"));
     }
     auth::check(host, request.headers(), tokens)?;
@@ -170,13 +170,13 @@ async fn delete(
         return Err(error::ErrorNotFound("file is not found or expired :(\n"));
     }
     match fs::remove_file(path) {
-        Ok(()) => log::info!("Deleted file: {:?}", file),
+        Ok(_) => log::info!("deleted file: {:?}", file),
         Err(e) => {
-            log::error!("Cannot delete file: {}", e);
+            log::error!("cannot delete file: {}", e);
             return Err(error::ErrorInternalServerError("cannot delete file"));
         }
     }
-    Ok(HttpResponse::Ok().finish())
+    Ok(HttpResponse::Ok().body(String::from("the file is deleted\n")))
 }
 
 /// Expose version endpoint

--- a/src/server.rs
+++ b/src/server.rs
@@ -7,7 +7,7 @@ use crate::paste::{Paste, PasteType};
 use crate::util;
 use actix_files::NamedFile;
 use actix_multipart::Multipart;
-use actix_web::{error, get, post, web, Error, HttpRequest, HttpResponse};
+use actix_web::{delete, error, get, post, web, Error, HttpRequest, HttpResponse};
 use awc::Client;
 use byte_unit::Byte;
 use futures_util::stream::StreamExt;
@@ -146,6 +146,33 @@ async fn serve(
     }
 }
 
+/// Remove a file from the upload directory.
+#[delete("/{file}")]
+async fn delete(
+    request: HttpRequest,
+    file: web::Path<String>,
+    config: web::Data<RwLock<Config>>,
+) -> Result<HttpResponse, Error> {
+    let config = config
+        .read()
+        .map_err(|_| error::ErrorInternalServerError("cannot acquire config"))?;
+    let path = config.server.upload_path.join(&*file);
+    let path = util::glob_match_file(path)?;
+    let connection = request.connection_info().clone();
+    let host = connection.realip_remote_addr().unwrap_or("unknown host");
+    let tokens = config.get_delete_tokens();
+    if tokens.is_none() {
+        log::warn!("delete endpoint not served because there are no delete_tokens set");
+        return Err(error::ErrorForbidden("endpoint is not exposed\n"));
+    }
+    auth::check(host, request.headers(), tokens)?;
+    if !path.is_file() || !path.exists() {
+        return Err(error::ErrorNotFound("file is not found or expired :(\n"));
+    }
+    fs::remove_file(path).expect("Could not delete file");
+    Ok(HttpResponse::Ok().finish())
+}
+
 /// Expose version endpoint
 #[get("/version")]
 async fn version(
@@ -157,7 +184,7 @@ async fn version(
         .map_err(|_| error::ErrorInternalServerError("cannot acquire config"))?;
     let connection = request.connection_info().clone();
     let host = connection.realip_remote_addr().unwrap_or("unknown host");
-    let tokens = config.get_tokens();
+    let tokens = config.get_auth_tokens();
     auth::check(host, request.headers(), tokens)?;
     if !config.server.expose_version.unwrap_or(false) {
         log::warn!("server is not configured to expose version endpoint");
@@ -181,7 +208,7 @@ async fn upload(
         let config = config
             .read()
             .map_err(|_| error::ErrorInternalServerError("cannot acquire config"))?;
-        let tokens = config.get_tokens();
+        let tokens = config.get_auth_tokens();
         auth::check(host, request.headers(), tokens)?;
     }
     let server_url = match config
@@ -315,7 +342,7 @@ async fn list(
         .clone();
     let connection = request.connection_info().clone();
     let host = connection.realip_remote_addr().unwrap_or("unknown host");
-    let tokens = config.get_tokens();
+    let tokens = config.get_auth_tokens();
     auth::check(host, request.headers(), tokens)?;
     if !config.server.expose_list.unwrap_or(false) {
         log::warn!("server is not configured to expose list endpoint");
@@ -370,6 +397,7 @@ pub fn configure_routes(cfg: &mut web::ServiceConfig) {
         .service(list)
         .service(serve)
         .service(upload)
+        .service(delete)
         .route("", web::head().to(HttpResponse::MethodNotAllowed));
 }
 
@@ -382,6 +410,7 @@ mod tests {
     use actix_web::body::MessageBody;
     use actix_web::body::{BodySize, BoxBody};
     use actix_web::error::Error;
+    use actix_web::http::header::AUTHORIZATION;
     use actix_web::http::{header, StatusCode};
     use actix_web::test::{self, TestRequest};
     use actix_web::web::Data;
@@ -720,6 +749,42 @@ mod tests {
         .await;
         assert_eq!(StatusCode::PAYLOAD_TOO_LARGE, response.status());
         assert_body(response.into_body().boxed(), "upload limit exceeded").await?;
+
+        Ok(())
+    }
+
+    #[actix_web::test]
+    async fn test_delete_file() -> Result<(), Error> {
+        let mut config = Config::default();
+        config.server.delete_tokens = Some(vec!["test".to_string()]);
+        config.server.upload_path = env::current_dir()?;
+
+        let app = test::init_service(
+            App::new()
+                .app_data(Data::new(RwLock::new(config)))
+                .app_data(Data::new(Client::default()))
+                .configure(configure_routes),
+        )
+        .await;
+
+        let file_name = "test_file.txt";
+        let timestamp = util::get_system_time()?.as_secs().to_string();
+        test::call_service(
+            &app,
+            get_multipart_request(&timestamp, "file", file_name).to_request(),
+        )
+        .await;
+
+        let request = TestRequest::delete()
+            .insert_header((AUTHORIZATION, header::HeaderValue::from_static("test")))
+            .uri(&format!("/{file_name}"))
+            .to_request();
+        let response = test::call_service(&app, request).await;
+
+        assert_eq!(StatusCode::OK, response.status());
+
+        let path = PathBuf::from(file_name);
+        assert!(!path.exists());
 
         Ok(())
     }

--- a/src/server.rs
+++ b/src/server.rs
@@ -169,7 +169,13 @@ async fn delete(
     if !path.is_file() || !path.exists() {
         return Err(error::ErrorNotFound("file is not found or expired :(\n"));
     }
-    fs::remove_file(path).expect("Could not delete file");
+    match fs::remove_file(path) {
+        Ok(()) => log::info!("Deleted file: {:?}", file),
+        Err(e) => {
+            log::error!("Cannot delete file: {}", e);
+            return Err(error::ErrorInternalServerError("cannot delete file"));
+        }
+    }
     Ok(HttpResponse::Ok().finish())
 }
 


### PR DESCRIPTION
## Description

Add a DELETE endpoint guarded by a separate auth token array.

## Motivation and Context

Closes #127 

## How Has This Been Tested?

Wrote a test case and tested manually.

## Changelog Entry

````
### Added

- Change `Config.get_tokens` to `Config.get_auth_tokens` and update invocations.
- Add delete_tokens array to config and `get_delete_tokens` method to Config for retrieving delete tokens.
- Add DELETE endpoint that will remove files if a delete token is set and authorized by the request.
- Test for new DELETE endpoint
- Add DELETE_TOKEN_ENV for setting the delete tokens array from an ENV var.
````
-->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
