### PR TITLE
refactor(server): change response to 'file deleted'

### DIFF
--- a/fixtures/test-file-delete/test.sh
+++ b/fixtures/test-file-delete/test.sh
@@ -9,7 +9,7 @@ setup() {
 run_test() {
   file_url=$(curl -s -F "file=@file" localhost:8000)
   test "$file_url" = "http://localhost:8000/file.txt"
-  test "the file is deleted" = "$(curl -s -H "Authorization: may_the_force_be_with_you" -X DELETE http://localhost:8000/file.txt)"
+  test "file deleted" = "$(curl -s -H "Authorization: may_the_force_be_with_you" -X DELETE http://localhost:8000/file.txt)"
   test "file is not found or expired :(" = "$(curl -s -H "Authorization: may_the_force_be_with_you" -X DELETE http://localhost:8000/file.txt)"
 }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -176,7 +176,7 @@ async fn delete(
             return Err(error::ErrorInternalServerError("cannot delete file"));
         }
     }
-    Ok(HttpResponse::Ok().body(String::from("the file is deleted\n")))
+    Ok(HttpResponse::Ok().body(String::from("file deleted\n")))
 }
 
 /// Expose version endpoint
@@ -788,6 +788,7 @@ mod tests {
         let response = test::call_service(&app, request).await;
 
         assert_eq!(StatusCode::OK, response.status());
+        assert_body(response.into_body(), "file deleted\n").await?;
 
         let path = PathBuf::from(file_name);
         assert!(!path.exists());


### PR DESCRIPTION
<!--- Thank you for contributing to rustypaste! -->

## Description

This PR just changes the srver resp9onse on successful file delete.

## Motivation and Context

see https://github.com/orhun/rustypaste-cli/pull/54#discussion_r1314312071

## How Has This Been Tested?

cargo test
fixtures
manual testing

## Changelog Entry

<!--- Please write the changelog entry for these changes. -->
<!--- Follow the <https://keepachangelog.com/en/1.0.0/> format. -->
<!--- Use one of the Added, Changed, Deprecated, Removed, Fixed, and Security headers accordingly. -->
````
### Changed

- Response message upon successful file deteletion
````

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [x] Other: change wording of server response
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
