### PR TITLE
test(fixtures): support `fixtures` on `macOS`

### DIFF
--- a/fixtures/test-expiring-file-upload/test.sh
+++ b/fixtures/test-expiring-file-upload/test.sh
@@ -9,7 +9,7 @@ setup() {
 run_test() {
   file_url=$(curl -s -F "file=@file" -H "expire:1s" localhost:8000)
   test "$content" = "$(cat upload/file.txt.*)"
-  sleep 2s
+  sleep 2
 
   result="$(curl -s $file_url)"
   test "file is not found or expired :(" = "$result"

--- a/fixtures/test-list-files/test.sh
+++ b/fixtures/test-list-files/test.sh
@@ -10,7 +10,7 @@ setup() {
 
 run_test() {
   seq $file_count | xargs -I -- curl -s -F "file=@file" -H "Authorization: $auth_token" localhost:8000 >/dev/null
-  test "$file_count" = "$(curl -s -H "Authorization: $auth_token" localhost:8000/list | grep -o 'file_name' | wc -l)"
+  test $file_count = $(curl -s -H "Authorization: $auth_token" localhost:8000/list | grep -o 'file_name' | wc -l)
   test "unauthorized" = "$(curl -s localhost:8000/list)"
 }
 

--- a/fixtures/test-server-auto-deletion/test.sh
+++ b/fixtures/test-server-auto-deletion/test.sh
@@ -11,10 +11,10 @@ run_test() {
   second_file_url=$(curl -s -F "file=@file" -H "expire:4s" localhost:8000)
   test "$content" = "$(curl -s $first_file_url)"
   test "$content" = "$(curl -s $second_file_url)"
-  sleep 3s
+  sleep 3
   test "file is not found or expired :(" = "$(curl -s $first_file_url)"
   test "$content" = "$(curl -s $second_file_url)"
-  sleep 1s
+  sleep 1
   test "file is not found or expired :(" = "$(curl -s $second_file_url)"
 }
 

--- a/fixtures/test-server-payload-limit/test.sh
+++ b/fixtures/test-server-payload-limit/test.sh
@@ -3,7 +3,8 @@
 setup() {
   touch emptyfile
   truncate -s 9KB smallfile
-  fallocate -l 10000 normalfile
+#  fallocate -l 10000 normalfile
+  dd if=/dev/random of=normalfile count=10000 bs=1024 status=none
   truncate -s 11KB bigfile
 }
 

--- a/fixtures/test-server-payload-limit/test.sh
+++ b/fixtures/test-server-payload-limit/test.sh
@@ -3,7 +3,7 @@
 setup() {
   touch emptyfile
   truncate -s 9KB smallfile
-#  fallocate -l 10000 normalfile
+  # On Linux, `fallocate -l 10000 normalfile` can be used for a better precision.
   dd if=/dev/random of=normalfile count=10000 bs=1024 status=none
   truncate -s 11KB bigfile
 }


### PR DESCRIPTION
<!--- Thank you for contributing to rustypaste! -->

## Description

Change fixtures to support macos as well as linux

## Motivation and Context

- `sleep` doesn't work with time-units (e.g `sleep 1s`)
- there is no `fallocate`  (`dd if=/dev/random of=normalfile count=10000 bs=1024 status=none` used)
- string formatting with substitution works incorrectly `"$(curl -s -H "Authorization: $auth_token" localhost:8000/list | grep -o 'file_name' | wc -l)"` returns `"     3"`, so it's not equal to `"3"`

## How Has This Been Tested?

Fixtures works on macOS and should pass CI (on lunux)

## Changelog Entry

````
### Changed

- Support fixtures on macOS
````

<!--- Please write the changelog entry for these changes. -->
<!--- Follow the <https://keepachangelog.com/en/1.0.0/> format. -->
<!--- Use one of the Added, Changed, Deprecated, Removed, Fixed, and Security headers accordingly. -->
<!-- For example:
````
### Added

- Add a middleware for checking the content length
  - Before, the upload size was checked after full upload which was clearly wrong.
````
-->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [X] Other <!--- (provide information) --> - Testing framework

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [X] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [X] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
