### PR TITLE
docs(readme): explain behavior of unset `auth_tokens` and `delete_tokens`

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ You can also set multiple auth tokens via the array field `[server].auth_tokens`
 
 > If neither `AUTH_TOKEN` nor `[server].auth_tokens` are set, the server will not require any authentication.
 >
-> Exception is the `DELETE` endpoint, which requires at least one token to be set. See [deleting file from server](#delete-file-from-server) for more information.
+> Exception is the `DELETE` endpoint, which requires at least one token to be set. See [deleting files from server](#delete-file-from-server) for more information.
 
 See [config.toml](./config.toml) for configuration options.
 

--- a/README.md
+++ b/README.md
@@ -252,6 +252,8 @@ Set `delete_tokens` array in [config.toml](./config.toml) to activate the [`DELE
 $ curl -H "Authorization: <auth_token>" -X DELETE "<server_address>/file.txt"
 ```
 
+> The `DELETE` endpoint will not be exposed and will return `404` error if `delete_tokens` are not set.
+
 ### Server
 
 To start the server:
@@ -274,6 +276,11 @@ $ rustypaste
 ```
 
 You can also set multiple auth tokens via the array field `[server].auth_tokens` in your `config.toml`.
+
+> If neither `AUTH_TOKEN` nor `[server].auth_tokens` are set, the server will not require any authentication.
+> 
+> Exception is the `DELETE` endpoint, which requires at least one token to be set. See [Delete file from server](#delete-file-from-server) for more information.
+
 
 See [config.toml](./config.toml) for configuration options.
 

--- a/README.md
+++ b/README.md
@@ -278,9 +278,8 @@ $ rustypaste
 You can also set multiple auth tokens via the array field `[server].auth_tokens` in your `config.toml`.
 
 > If neither `AUTH_TOKEN` nor `[server].auth_tokens` are set, the server will not require any authentication.
-> 
-> Exception is the `DELETE` endpoint, which requires at least one token to be set. See [Delete file from server](#delete-file-from-server) for more information.
-
+>
+> Exception is the `DELETE` endpoint, which requires at least one token to be set. See [deleting file from server](#delete-file-from-server) for more information.
 
 See [config.toml](./config.toml) for configuration options.
 


### PR DESCRIPTION
<!--- Thank you for contributing to rustypaste! -->

## Description

Just a clarification on how this works in the case of uninstalled tokens, for greater clarity and security

## Motivation and Context

Discussed as part of #199, just to clarify the behavior 

## Changelog Entry

<!--- Please write the changelog entry for these changes. -->
<!--- Follow the <https://keepachangelog.com/en/1.0.0/> format. -->
<!--- Use one of the Added, Changed, Deprecated, Removed, Fixed, and Security headers accordingly. -->
<!-- For example:
````
### Added

- Clarify the behavior in case of `auth_tokens` or `delete_tokens` are not set
````
-->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [ ] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [ ] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
