### PR TITLE
fix(auth): remove excessive warning and typo

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -33,11 +33,10 @@ pub(crate) async fn extract_tokens(req: &ServiceRequest) -> Result<HashSet<Token
             }
         } else if token_type == TokenType::Auth {
             // not configured `auth_tokens` means that the user is allowed to access the endpoints
-            warn!("auth_tokens not configured, allowing the request without auth header");
             user_tokens.insert(token_type);
         } else if token_type == TokenType::Delete && req.method() == Method::DELETE {
             // explicitly disable `DELETE` methods if no `delete_tokens` are set
-            warn!("delete endpoints is not served because there are no delete_tokens set");
+            warn!("delete endpoint is not served because there are no delete_tokens set");
             Err(error::ErrorNotFound(""))?;
         }
     }


### PR DESCRIPTION
<!--- Thank you for contributing to rustypaste! -->

## Description

Iff one doesn't use auth tokens, their log is spammed with warning messages.
This change removes the warning message.

It also fixes a small typo.

## Motivation and Context

Fixes #209

## How Has This Been Tested?

cargo test
fixtures

## Changelog Entry

<!--- Please write the changelog entry for these changes. -->
<!--- Follow the <https://keepachangelog.com/en/1.0.0/> format. -->
<!--- Use one of the Added, Changed, Deprecated, Removed, Fixed, and Security headers accordingly. -->
<!-- For example:
````
### Fixed

- Removed excessive warning messages
- Fixed typo
````
-->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
