### PR TITLE
feat(server): allow to override filename when using random_url

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Here you can read the blog post about how it is deployed on Shuttle: [https://bl
     - [Paste file from remote URL](#paste-file-from-remote-url)
     - [Cleaning up expired files](#cleaning-up-expired-files)
     - [Delete file from server](#delete-file-from-server)
+    - [Override the filename when using `random_url`](#override-the-filename-when-using-random_url)
   - [Server](#server)
     - [List endpoint](#list-endpoint)
     - [HTML Form](#html-form)
@@ -72,6 +73,7 @@ Here you can read the blog post about how it is deployed on Shuttle: [https://bl
     - pet name (e.g. `capital-mosquito.txt`)
     - alphanumeric string (e.g. `yB84D2Dv.txt`)
     - random suffix (e.g. `file.MRV5as.tar.gz`)
+    - supports overriding the filename
   - supports expiring links
     - auto-expiration of files (optional)
     - auto-deletion of expired files (optional)
@@ -253,6 +255,14 @@ $ curl -H "Authorization: <auth_token>" -X DELETE "<server_address>/file.txt"
 ```
 
 > The `DELETE` endpoint will not be exposed and will return `404` error if `delete_tokens` are not set.
+
+#### Override the filename when using `random_url`
+
+The generation of a random filename can be overridden by sending a header called `filename`:
+
+```sh
+curl -F "file=@x.txt" -H "filename: <file_name>" "<server_address>"
+```
 
 ### Server
 

--- a/fixtures/test-file-upload-override-filename/config.toml
+++ b/fixtures/test-file-upload-override-filename/config.toml
@@ -1,0 +1,9 @@
+[server]
+address = "127.0.0.1:8000"
+max_content_length = "10MB"
+upload_path = "./upload"
+
+[paste]
+random_url = { type = "alphanumeric", length = "4", suffix_mode = true }
+default_extension = "txt"
+duplicate_files = true

--- a/fixtures/test-file-upload-override-filename/test.sh
+++ b/fixtures/test-file-upload-override-filename/test.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+content="test data"
+
+setup() {
+  echo "$content" > file
+}
+
+run_test() {
+  file_url=$(curl -s -F "file=@file" -H "filename:fn_from_header.txt" localhost:8000)
+  test "$file_url" = "http://localhost:8000/fn_from_header.txt"
+  test "$content" = "$(cat upload/fn_from_header.txt)"
+  test "$content" = "$(curl -s $file_url)"
+}
+
+teardown() {
+  rm file
+  rm -r upload
+}

--- a/src/header.rs
+++ b/src/header.rs
@@ -7,12 +7,24 @@ use std::time::Duration;
 /// Custom HTTP header for expiry dates.
 pub const EXPIRE: &str = "expire";
 
+/// Custom HTTP header to override filename.
+pub const FILENAME: &str = "filename";
+
 /// Parses the expiry date from the [`custom HTTP header`](EXPIRE).
 pub fn parse_expiry_date(headers: &HeaderMap, time: Duration) -> Result<Option<u128>, ActixError> {
     if let Some(expire_time) = headers.get(EXPIRE).and_then(|v| v.to_str().ok()) {
         let expire_time =
             humantime::parse_duration(expire_time).map_err(error::ErrorInternalServerError)?;
         Ok(time.checked_add(expire_time).map(|t| t.as_millis()))
+    } else {
+        Ok(None)
+    }
+}
+
+/// Parses the filename from the header.
+pub fn parse_header_filename(headers: &HeaderMap) -> Result<Option<String>, ActixError> {
+    if let Some(file_name) = headers.get(FILENAME).and_then(|v| v.to_str().ok()) {
+        Ok(Some(file_name.to_string()))
     } else {
         Ok(None)
     }


### PR DESCRIPTION
## Description

```bash
curl -F "file=@x.txt" -H "filename:override.txt" http://localhost:8000
```

Even if `random_url` is set, the filename will be `override.txt` (the name specified in the header `filename`).

## Motivation and Context

See issue #217 

closes #217

## How Has This Been Tested?

- manually
- cargo test
- fixtures

## Changelog Entry

````
### Added

- Allow to override the filename when using `random_url`
````

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
