### PR TITLE
feat(server): do path joins more safely

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1939,6 +1939,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
 
 [[package]]
+name = "path-clean"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17359afc20d7ab31fdb42bb844c8b3bb1dabd7dcf7e68428492da7f16966fcef"
+
+[[package]]
 name = "pathdiff"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2425,6 +2431,7 @@ dependencies = [
  "infer",
  "lazy-regex",
  "mime",
+ "path-clean",
  "petname",
  "rand",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ tokio = { version = "1.35.1", optional = true }
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 uts2ts = "0.4.1"
+path-clean = "1.0.1"
 
 [dependencies.config]
 version = "0.13.4"

--- a/src/main.rs
+++ b/src/main.rs
@@ -71,7 +71,11 @@ fn setup(config_folder: &Path) -> IoResult<(Data<RwLock<Config>>, ServerConfig, 
     // Create necessary directories.
     fs::create_dir_all(&server_config.upload_path)?;
     for paste_type in &[PasteType::Url, PasteType::Oneshot, PasteType::OneshotUrl] {
-        fs::create_dir_all(paste_type.get_path(&server_config.upload_path))?;
+        fs::create_dir_all(
+            paste_type
+                .get_path(&server_config.upload_path)
+                .expect("failed to get path for paste type"),
+        )?;
     }
 
     // Set up a watcher for the configuration file changes.

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,7 @@ use rustypaste::util;
 use rustypaste::CONFIG_ENV;
 use std::env;
 use std::fs;
-use std::io::{Error as IoError, ErrorKind as IoErrorKind, Result as IoResult};
+use std::io::Result as IoResult;
 use std::path::{Path, PathBuf};
 use std::sync::{mpsc, RwLock};
 use std::thread;
@@ -71,13 +71,7 @@ fn setup(config_folder: &Path) -> IoResult<(Data<RwLock<Config>>, ServerConfig, 
     // Create necessary directories.
     fs::create_dir_all(&server_config.upload_path)?;
     for paste_type in &[PasteType::Url, PasteType::Oneshot, PasteType::OneshotUrl] {
-        let upload_path = paste_type
-            .get_path(&server_config.upload_path)
-            .ok_or(IoError::new(
-                IoErrorKind::Other,
-                String::from("Invalid upload path"),
-            ))?;
-        fs::create_dir_all(upload_path)?;
+        fs::create_dir_all(paste_type.get_path(&server_config.upload_path)?)?;
     }
 
     // Set up a watcher for the configuration file changes.

--- a/src/main.rs
+++ b/src/main.rs
@@ -71,13 +71,13 @@ fn setup(config_folder: &Path) -> IoResult<(Data<RwLock<Config>>, ServerConfig, 
     // Create necessary directories.
     fs::create_dir_all(&server_config.upload_path)?;
     for paste_type in &[PasteType::Url, PasteType::Oneshot, PasteType::OneshotUrl] {
-        let _ = paste_type
+        let upload_path = paste_type
             .get_path(&server_config.upload_path)
             .ok_or(IoError::new(
                 IoErrorKind::Other,
                 String::from("Invalid upload path"),
-            ))
-            .map(fs::create_dir_all)?;
+            ))?;
+        fs::create_dir_all(upload_path)?;
     }
 
     // Set up a watcher for the configuration file changes.

--- a/src/paste.rs
+++ b/src/paste.rs
@@ -58,12 +58,12 @@ impl PasteType {
     }
 
     /// Returns the given path with [`directory`](Self::get_dir) adjoined.
-    pub fn get_path(&self, path: &Path) -> PathBuf {
+    pub fn get_path(&self, path: &Path) -> Option<PathBuf> {
         let dir = self.get_dir();
         if dir.is_empty() {
-            path.to_path_buf()
+            Some(path.to_path_buf())
         } else {
-            util::safe_path_join(path, Path::new(&dir)).unwrap()
+            util::safe_path_join(path, Path::new(&dir))
         }
     }
 
@@ -122,12 +122,20 @@ impl Paste {
         if let Some(handle_spaces_config) = config.server.handle_spaces {
             file_name = handle_spaces_config.process_filename(&file_name);
         }
-        let mut path =
-            util::safe_path_join(self.type_.get_path(&config.server.upload_path), &file_name)
+
+        let mut path = util::safe_path_join(
+            self.type_
+                .get_path(&config.server.upload_path)
                 .ok_or(IoError::new(
                     IoErrorKind::Other,
                     String::from("invalid filename"),
-                ))?;
+                ))?,
+            &file_name,
+        )
+        .ok_or(IoError::new(
+            IoErrorKind::Other,
+            String::from("invalid filename"),
+        ))?;
         let mut parts: Vec<&str> = file_name.split('.').collect();
         let mut dotfile = false;
         let mut lower_bound = 1;
@@ -263,12 +271,19 @@ impl Paste {
                 file_name = random_text;
             }
         }
-        let mut path =
-            util::safe_path_join(self.type_.get_path(&config.server.upload_path), &file_name)
+        let mut path = util::safe_path_join(
+            self.type_
+                .get_path(&config.server.upload_path)
                 .ok_or(IoError::new(
                     IoErrorKind::Other,
                     String::from("invalid filename"),
-                ))?;
+                ))?,
+            &file_name,
+        )
+        .ok_or(IoError::new(
+            IoErrorKind::Other,
+            String::from("invalid filename"),
+        ))?;
         if let Some(timestamp) = expiry_date {
             path.set_file_name(format!("{file_name}.{timestamp}"));
         }
@@ -434,7 +449,7 @@ mod tests {
         fs::remove_file(file_name)?;
 
         for paste_type in &[PasteType::Url, PasteType::Oneshot] {
-            fs::create_dir_all(paste_type.get_path(&config.server.upload_path))?;
+            fs::create_dir_all(paste_type.get_path(&config.server.upload_path).unwrap())?;
         }
 
         config.paste.random_url = None;
@@ -446,6 +461,7 @@ mod tests {
         let file_name = paste.store_file("test.file", Some(expiry_date), None, &config)?;
         let file_path = PasteType::Oneshot
             .get_path(&config.server.upload_path)
+            .unwrap()
             .join(format!("{file_name}.{expiry_date}"));
         assert_eq!("test", fs::read_to_string(&file_path)?);
         fs::remove_file(file_path)?;
@@ -462,6 +478,7 @@ mod tests {
         let file_name = paste.store_url(None, &config)?;
         let file_path = PasteType::Url
             .get_path(&config.server.upload_path)
+            .unwrap()
             .join(&file_name);
         assert_eq!(url, fs::read_to_string(&file_path)?);
         fs::remove_file(file_path)?;
@@ -489,6 +506,7 @@ mod tests {
             .await?;
         let file_path = PasteType::RemoteFile
             .get_path(&config.server.upload_path)
+            .unwrap()
             .join(file_name);
         assert_eq!(
             "8c712905b799905357b8202d0cb7a244cefeeccf7aa5eb79896645ac50158ffa",
@@ -497,7 +515,7 @@ mod tests {
         fs::remove_file(file_path)?;
 
         for paste_type in &[PasteType::Url, PasteType::Oneshot] {
-            fs::remove_dir(paste_type.get_path(&config.server.upload_path))?;
+            fs::remove_dir(paste_type.get_path(&config.server.upload_path).unwrap())?;
         }
 
         Ok(())

--- a/src/paste.rs
+++ b/src/paste.rs
@@ -63,7 +63,7 @@ impl PasteType {
         if dir.is_empty() {
             path.to_path_buf()
         } else {
-            path.join(dir)
+            util::safe_path_join(path, Path::new(&dir)).unwrap()
         }
     }
 
@@ -122,10 +122,12 @@ impl Paste {
         if let Some(handle_spaces_config) = config.server.handle_spaces {
             file_name = handle_spaces_config.process_filename(&file_name);
         }
-        let mut path = self
-            .type_
-            .get_path(&config.server.upload_path)
-            .join(&file_name);
+        let mut path =
+            util::safe_path_join(self.type_.get_path(&config.server.upload_path), &file_name)
+                .ok_or(IoError::new(
+                    IoErrorKind::Other,
+                    String::from("invalid filename"),
+                ))?;
         let mut parts: Vec<&str> = file_name.split('.').collect();
         let mut dotfile = false;
         let mut lower_bound = 1;
@@ -261,10 +263,12 @@ impl Paste {
                 file_name = random_text;
             }
         }
-        let mut path = self
-            .type_
-            .get_path(&config.server.upload_path)
-            .join(&file_name);
+        let mut path =
+            util::safe_path_join(self.type_.get_path(&config.server.upload_path), &file_name)
+                .ok_or(IoError::new(
+                    IoErrorKind::Other,
+                    String::from("Invalid filename"),
+                ))?;
         if let Some(timestamp) = expiry_date {
             path.set_file_name(format!("{file_name}.{timestamp}"));
         }

--- a/src/paste.rs
+++ b/src/paste.rs
@@ -58,10 +58,10 @@ impl PasteType {
     }
 
     /// Returns the given path with [`directory`](Self::get_dir) adjoined.
-    pub fn get_path(&self, path: &Path) -> Option<PathBuf> {
+    pub fn get_path(&self, path: &Path) -> IoResult<PathBuf> {
         let dir = self.get_dir();
         if dir.is_empty() {
-            Some(path.to_path_buf())
+            Ok(path.to_path_buf())
         } else {
             util::safe_path_join(path, Path::new(&dir))
         }
@@ -123,19 +123,8 @@ impl Paste {
             file_name = handle_spaces_config.process_filename(&file_name);
         }
 
-        let mut path = util::safe_path_join(
-            self.type_
-                .get_path(&config.server.upload_path)
-                .ok_or(IoError::new(
-                    IoErrorKind::Other,
-                    String::from("invalid filename"),
-                ))?,
-            &file_name,
-        )
-        .ok_or(IoError::new(
-            IoErrorKind::Other,
-            String::from("invalid filename"),
-        ))?;
+        let mut path =
+            util::safe_path_join(self.type_.get_path(&config.server.upload_path)?, &file_name)?;
         let mut parts: Vec<&str> = file_name.split('.').collect();
         let mut dotfile = false;
         let mut lower_bound = 1;
@@ -271,19 +260,8 @@ impl Paste {
                 file_name = random_text;
             }
         }
-        let mut path = util::safe_path_join(
-            self.type_
-                .get_path(&config.server.upload_path)
-                .ok_or(IoError::new(
-                    IoErrorKind::Other,
-                    String::from("invalid filename"),
-                ))?,
-            &file_name,
-        )
-        .ok_or(IoError::new(
-            IoErrorKind::Other,
-            String::from("invalid filename"),
-        ))?;
+        let mut path =
+            util::safe_path_join(self.type_.get_path(&config.server.upload_path)?, &file_name)?;
         if let Some(timestamp) = expiry_date {
             path.set_file_name(format!("{file_name}.{timestamp}"));
         }

--- a/src/paste.rs
+++ b/src/paste.rs
@@ -449,7 +449,11 @@ mod tests {
         fs::remove_file(file_name)?;
 
         for paste_type in &[PasteType::Url, PasteType::Oneshot] {
-            fs::create_dir_all(paste_type.get_path(&config.server.upload_path).unwrap())?;
+            fs::create_dir_all(
+                paste_type
+                    .get_path(&config.server.upload_path)
+                    .expect("Bad upload path"),
+            )?;
         }
 
         config.paste.random_url = None;
@@ -461,7 +465,7 @@ mod tests {
         let file_name = paste.store_file("test.file", Some(expiry_date), None, &config)?;
         let file_path = PasteType::Oneshot
             .get_path(&config.server.upload_path)
-            .unwrap()
+            .expect("Bad upload path")
             .join(format!("{file_name}.{expiry_date}"));
         assert_eq!("test", fs::read_to_string(&file_path)?);
         fs::remove_file(file_path)?;
@@ -478,7 +482,7 @@ mod tests {
         let file_name = paste.store_url(None, &config)?;
         let file_path = PasteType::Url
             .get_path(&config.server.upload_path)
-            .unwrap()
+            .expect("Bad upload path")
             .join(&file_name);
         assert_eq!(url, fs::read_to_string(&file_path)?);
         fs::remove_file(file_path)?;
@@ -506,7 +510,7 @@ mod tests {
             .await?;
         let file_path = PasteType::RemoteFile
             .get_path(&config.server.upload_path)
-            .unwrap()
+            .expect("Bad upload path")
             .join(file_name);
         assert_eq!(
             "8c712905b799905357b8202d0cb7a244cefeeccf7aa5eb79896645ac50158ffa",
@@ -515,7 +519,11 @@ mod tests {
         fs::remove_file(file_path)?;
 
         for paste_type in &[PasteType::Url, PasteType::Oneshot] {
-            fs::remove_dir(paste_type.get_path(&config.server.upload_path).unwrap())?;
+            fs::remove_dir(
+                paste_type
+                    .get_path(&config.server.upload_path)
+                    .expect("Bad upload path"),
+            )?;
         }
 
         Ok(())

--- a/src/paste.rs
+++ b/src/paste.rs
@@ -267,7 +267,7 @@ impl Paste {
             util::safe_path_join(self.type_.get_path(&config.server.upload_path), &file_name)
                 .ok_or(IoError::new(
                     IoErrorKind::Other,
-                    String::from("Invalid filename"),
+                    String::from("invalid filename"),
                 ))?;
         if let Some(timestamp) = expiry_date {
             path.set_file_name(format!("{file_name}.{timestamp}"));

--- a/src/server.rs
+++ b/src/server.rs
@@ -89,19 +89,11 @@ async fn serve(
     let config = config
         .read()
         .map_err(|_| error::ErrorInternalServerError("cannot acquire config"))?;
-    let path = safe_path_join(&config.server.upload_path, &*file)
-        .ok_or(error::ErrorInternalServerError("Invalid filename"))?;
-    let mut path = util::glob_match_file(path)?;
+    let mut path = util::glob_match_file(safe_path_join(&config.server.upload_path, &*file)?)?;
     let mut paste_type = PasteType::File;
     if !path.exists() || path.is_dir() {
         for type_ in &[PasteType::Url, PasteType::Oneshot, PasteType::OneshotUrl] {
-            let alt_path = safe_path_join(
-                type_
-                    .get_path(&config.server.upload_path)
-                    .ok_or(error::ErrorInternalServerError("invalid filename"))?,
-                &*file,
-            )
-            .ok_or(error::ErrorInternalServerError("invalid filename"))?;
+            let alt_path = safe_path_join(type_.get_path(&config.server.upload_path)?, &*file)?;
             let alt_path = util::glob_match_file(alt_path)?;
             if alt_path.exists()
                 || path.file_name().and_then(|v| v.to_str()) == Some(&type_.get_dir())
@@ -166,9 +158,7 @@ async fn delete(
     let config = config
         .read()
         .map_err(|_| error::ErrorInternalServerError("cannot acquire config"))?;
-    let path = safe_path_join(&config.server.upload_path, &*file)
-        .ok_or(error::ErrorInternalServerError("Invalid filename"))?;
-    let path = util::glob_match_file(path)?;
+    let path = util::glob_match_file(safe_path_join(&config.server.upload_path, &*file)?)?;
     if !path.is_file() || !path.exists() {
         return Err(error::ErrorNotFound("file is not found or expired :(\n"));
     }

--- a/src/server.rs
+++ b/src/server.rs
@@ -95,8 +95,13 @@ async fn serve(
     let mut paste_type = PasteType::File;
     if !path.exists() || path.is_dir() {
         for type_ in &[PasteType::Url, PasteType::Oneshot, PasteType::OneshotUrl] {
-            let alt_path = safe_path_join(type_.get_path(&config.server.upload_path), &*file)
-                .ok_or(error::ErrorInternalServerError("Invalid filename"))?;
+            let alt_path = safe_path_join(
+                type_
+                    .get_path(&config.server.upload_path)
+                    .ok_or(error::ErrorInternalServerError("invalid filename"))?,
+                &*file,
+            )
+            .ok_or(error::ErrorInternalServerError("invalid filename"))?;
             let alt_path = util::glob_match_file(alt_path)?;
             if alt_path.exists()
                 || path.file_name().and_then(|v| v.to_str()) == Some(&type_.get_dir())
@@ -1090,7 +1095,7 @@ mod tests {
         )
         .await;
 
-        let url_upload_path = PasteType::Url.get_path(&config.server.upload_path);
+        let url_upload_path = PasteType::Url.get_path(&config.server.upload_path).unwrap();
         fs::create_dir_all(&url_upload_path)?;
 
         let response = test::call_service(
@@ -1128,7 +1133,9 @@ mod tests {
         )
         .await;
 
-        let oneshot_upload_path = PasteType::Oneshot.get_path(&config.server.upload_path);
+        let oneshot_upload_path = PasteType::Oneshot
+            .get_path(&config.server.upload_path)
+            .unwrap();
         fs::create_dir_all(&oneshot_upload_path)?;
 
         let file_name = "oneshot.txt";
@@ -1188,7 +1195,9 @@ mod tests {
         )
         .await;
 
-        let url_upload_path = PasteType::OneshotUrl.get_path(&config.server.upload_path);
+        let url_upload_path = PasteType::OneshotUrl
+            .get_path(&config.server.upload_path)
+            .unwrap();
         fs::create_dir_all(&url_upload_path)?;
 
         let response = test::call_service(

--- a/src/server.rs
+++ b/src/server.rs
@@ -1095,7 +1095,9 @@ mod tests {
         )
         .await;
 
-        let url_upload_path = PasteType::Url.get_path(&config.server.upload_path).unwrap();
+        let url_upload_path = PasteType::Url
+            .get_path(&config.server.upload_path)
+            .expect("Bad upload path");
         fs::create_dir_all(&url_upload_path)?;
 
         let response = test::call_service(
@@ -1135,7 +1137,7 @@ mod tests {
 
         let oneshot_upload_path = PasteType::Oneshot
             .get_path(&config.server.upload_path)
-            .unwrap();
+            .expect("Bad upload path");
         fs::create_dir_all(&oneshot_upload_path)?;
 
         let file_name = "oneshot.txt";
@@ -1197,7 +1199,7 @@ mod tests {
 
         let url_upload_path = PasteType::OneshotUrl
             .get_path(&config.server.upload_path)
-            .unwrap();
+            .expect("Bad upload path");
         fs::create_dir_all(&url_upload_path)?;
 
         let response = test::call_service(

--- a/src/util.rs
+++ b/src/util.rs
@@ -65,7 +65,8 @@ pub fn get_expired_files(base_path: &Path) -> Vec<PathBuf> {
         PasteType::OneshotUrl,
     ]
     .into_iter()
-    .filter_map(|v| glob(&v.get_path(base_path).join("*.[0-9]*").to_string_lossy()).ok())
+    .filter_map(|v| v.get_path(base_path))
+    .filter_map(|v| glob(&v.join("*.[0-9]*").to_string_lossy()).ok())
     .flat_map(|glob| glob.filter_map(|v| v.ok()).collect::<Vec<PathBuf>>())
     .filter(|path| {
         if let Some(extension) = path


### PR DESCRIPTION
## Description

Check that a joined path is still a child of the original path.

## Motivation and Context


When joining paths, there's little protection against directory traversal. From testing, Actix seems to nicely sanitises these in the request, which is great, but it's still better to add a little protection.

## How Has This Been Tested?

Unit tests have been added, which pass.

## Changelog Entry

<!--- Please write the changelog entry for these changes. -->
<!--- Follow the <https://keepachangelog.com/en/1.0.0/> format. -->
<!--- Use one of the Added, Changed, Deprecated, Removed, Fixed, and Security headers accordingly. -->
<!-- For example:
````
### Added

- Add a middleware for checking the content length
  - Before, the upload size was checked after full upload which was clearly wrong.
````
-->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [ ] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [ ] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
