### PR TITLE
test(upload): update the hash of the example file

### DIFF
--- a/src/paste.rs
+++ b/src/paste.rs
@@ -487,7 +487,7 @@ mod tests {
             .get_path(&config.server.upload_path)
             .join(file_name);
         assert_eq!(
-            "8c712905b799905357b8202d0cb7a244cefeeccf7aa5eb79896645ac50158ffa",
+            "70ff72a2f7651b5fae3aa9834e03d2a2233c52036610562f7fa04e089e8198ed",
             util::sha256_digest(&*paste.data)?
         );
         fs::remove_file(file_path)?;

--- a/src/server.rs
+++ b/src/server.rs
@@ -1059,7 +1059,7 @@ mod tests {
         let body = response.into_body();
         let body_bytes = actix_web::body::to_bytes(body).await?;
         assert_eq!(
-            "8c712905b799905357b8202d0cb7a244cefeeccf7aa5eb79896645ac50158ffa",
+            "70ff72a2f7651b5fae3aa9834e03d2a2233c52036610562f7fa04e089e8198ed",
             util::sha256_digest(&*body_bytes)?
         );
 


### PR DESCRIPTION
## Description

The file `https://upload.wikimedia.org/wikipedia/en/a/a9/Example.jpg` was replaced by a different version on March 1st.

I checked, the old file still exists and the hash is the same, but unfortunately the `util::sha256_digest` seems to take the filename into account, because I tried to replace the link, but the hash changed in the rustypaste tests as well. When I check the hash on the commandline with `shasum`, it's actually the same though.

Since the hash changes either way, I just updated the hash, instead of link and hash.

## Motivation and Context

fixes #253 

## How Has This Been Tested?

cargo test
fixtures

## Changelog Entry

<!--- Please write the changelog entry for these changes. -->
<!--- Follow the <https://keepachangelog.com/en/1.0.0/> format. -->
<!--- Use one of the Added, Changed, Deprecated, Removed, Fixed, and Security headers accordingly. -->

````
### Fixed

- update hash in tests, since the file changed at source
````


## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
