### PR TITLE
fix(upload): error on upload with the same filename

### DIFF
--- a/fixtures/test-file-upload-same-filename/config.toml
+++ b/fixtures/test-file-upload-same-filename/config.toml
@@ -1,0 +1,9 @@
+[server]
+address = "127.0.0.1:8000"
+max_content_length = "10MB"
+upload_path = "./upload"
+
+[paste]
+random_url = { type = "alphanumeric", length = "4", suffix_mode = true }
+default_extension = "txt"
+duplicate_files = true

--- a/fixtures/test-file-upload-same-filename/test.sh
+++ b/fixtures/test-file-upload-same-filename/test.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+content="test data"
+
+setup() {
+  echo "$content" > file
+}
+
+run_test() {
+  file_url=$(curl -s -F "file=@file" -H "filename:fn_from_header.txt" localhost:8000)
+  test "$file_url" = "http://localhost:8000/fn_from_header.txt"
+  test "$content" = "$(cat upload/fn_from_header.txt)"
+  test "$content" = "$(curl -s $file_url)"
+  file_url=$(curl -s -F "file=@file" -H "filename:fn_from_header.txt" localhost:8000)
+  test "$file_url" = "file already exists"
+}
+
+teardown() {
+  rm file
+  rm -r upload
+}

--- a/src/paste.rs
+++ b/src/paste.rs
@@ -176,6 +176,14 @@ impl Paste {
             .map(|v| v.to_string_lossy())
             .unwrap_or_default()
             .to_string();
+        let file_path = util::glob_match_file(path.clone())
+            .map_err(|_| IoError::new(IoErrorKind::Other, String::from("path is not valid")))?;
+        if file_path.is_file() && file_path.exists() {
+            return Err(IoError::new(
+                IoErrorKind::AlreadyExists,
+                String::from("file already exists\n"),
+            ));
+        }
         if let Some(timestamp) = expiry_date {
             path.set_file_name(format!("{file_name}.{timestamp}"));
         }


### PR DESCRIPTION
## Description

Currently it is possible to upload files with the same name. This is undefined behavior. e.g. which file should be returned when accessing it?

To solve this problem this change introduces a check whether a file (that hasn't expired) alredy exists with the same name. If so, an error will be returned.

## Motivation and Context

see https://github.com/orhun/rustypaste/discussions/241

I am opening this PR now, because I want to check, whether the test that fails in #246 also fails with this one.

Depending on which PR is merged first, a change will be required to add an `.await` to the `glob_match_file` call.

## How Has This Been Tested?

- manually
- cargo tests (new tests)
- fixtures (new tests)

## Changelog Entry

<!--- Please write the changelog entry for these changes. -->
<!--- Follow the <https://keepachangelog.com/en/1.0.0/> format. -->
<!--- Use one of the Added, Changed, Deprecated, Removed, Fixed, and Security headers accordingly. -->

````
### Changed

- Return an error when a file with the same name already exists on the server
````

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
