### PR TITLE
refactor(server): use more specific HTTP status codes

### DIFF
--- a/fixtures/test-file-upload-same-filename/test.sh
+++ b/fixtures/test-file-upload-same-filename/test.sh
@@ -13,6 +13,8 @@ run_test() {
   test "$content" = "$(curl -s $file_url)"
   file_url=$(curl -s -F "file=@file" -H "filename:fn_from_header.txt" localhost:8000)
   test "$file_url" = "file already exists"
+  status_code=$(curl -s -F "file=@file" -H "filename:fn_from_header.txt" -w "%{response_code}" -o /dev/null localhost:8000)
+  test "$status_code" = "409"
 }
 
 teardown() {

--- a/fixtures/test-server-mime-blacklist/test.sh
+++ b/fixtures/test-server-mime-blacklist/test.sh
@@ -11,6 +11,7 @@ setup() {
 run_test() {
   test "this file type is not permitted" = "$(curl -s -F "file=@file.html" localhost:8000)"
   test "this file type is not permitted" = "$(curl -s -F "file=@file.xml" localhost:8000)"
+  test "415" = "$(curl -s -F "file=@file.xml" -w "%{response_code}" -o /dev/null localhost:8000)"
   file_url=$(curl -s -F "file=@file.txt" localhost:8000)
   test "$content" = "$(curl -s $file_url)"
 }

--- a/src/paste.rs
+++ b/src/paste.rs
@@ -244,7 +244,7 @@ impl Paste {
                     .to_string());
             }
         }
-        Ok(self.store_file(file_name, expiry_date, None, &config)?)
+        self.store_file(file_name, expiry_date, None, &config)
     }
 
     /// Writes an URL to a file in upload directory.

--- a/src/paste.rs
+++ b/src/paste.rs
@@ -98,14 +98,13 @@ impl Paste {
         expiry_date: Option<u128>,
         header_filename: Option<String>,
         config: &Config,
-    ) -> IoResult<String> {
+    ) -> Result<String, Error> {
         let file_type = infer::get(&self.data);
         if let Some(file_type) = file_type {
             for mime_type in &config.paste.mime_blacklist {
                 if mime_type == file_type.mime_type() {
-                    return Err(IoError::new(
-                        IoErrorKind::Other,
-                        String::from("this file type is not permitted"),
+                    return Err(error::ErrorUnsupportedMediaType(
+                        "this file type is not permitted",
                     ));
                 }
             }
@@ -179,10 +178,7 @@ impl Paste {
         let file_path = util::glob_match_file(path.clone())
             .map_err(|_| IoError::new(IoErrorKind::Other, String::from("path is not valid")))?;
         if file_path.is_file() && file_path.exists() {
-            return Err(IoError::new(
-                IoErrorKind::AlreadyExists,
-                String::from("file already exists\n"),
-            ));
+            return Err(error::ErrorConflict("file already exists\n"));
         }
         if let Some(timestamp) = expiry_date {
             path.set_file_name(format!("{file_name}.{timestamp}"));

--- a/src/server.rs
+++ b/src/server.rs
@@ -951,15 +951,10 @@ mod tests {
                 .to_request(),
         )
         .await;
-        assert_eq!(StatusCode::INTERNAL_SERVER_ERROR, response.status());
+        assert_eq!(StatusCode::CONFLICT, response.status());
         assert_body(response.into_body(), "file already exists\n").await?;
 
         fs::remove_file(header_filename)?;
-        let serve_request = TestRequest::get()
-            .uri(&format!("/{header_filename}"))
-            .to_request();
-        let response = test::call_service(&app, serve_request).await;
-        assert_eq!(StatusCode::NOT_FOUND, response.status());
 
         Ok(())
     }


### PR DESCRIPTION
## Description

This change returns a more appropriate status code in 2 cases instead of a generic 500 code:

- UnsupportedMediaType (if the mime type is on the blacklist)
- Conflict (if the file already exists)

## Motivation and Context

closes #261 

## How Has This Been Tested?

- cargo test
- fixtures

## Changelog Entry

<!--- Please write the changelog entry for these changes. -->
<!--- Follow the <https://keepachangelog.com/en/1.0.0/> format. -->
<!--- Use one of the Added, Changed, Deprecated, Removed, Fixed, and Security headers accordingly. -->
````
### Changed

- Return appropriate HTTP status code instead of 500
````

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [x] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [x] I have added (in this case changed) tests to cover my changes.
- [x] All new and existing tests passed.
