### PR TITLE
feat(server): add support for multiple auth tokens via env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,8 @@ If the configuration file is not found in the current directory, specify it via 
 $ CONFIG="$HOME/.rustypaste.toml" rustypaste
 ```
 
+#### Authentication
+
 To enable basic HTTP auth, set the `AUTH_TOKEN` environment variable (via `.env`):
 
 ```sh
@@ -287,7 +289,7 @@ $ echo "AUTH_TOKEN=$(openssl rand -base64 16)" > .env
 $ rustypaste
 ```
 
-You can also set multiple auth tokens via the array field `[server].auth_tokens` in your `config.toml`.
+There are 2 options for setting multiple auth tokens:
 
 - Via the array field `[server].auth_tokens` in your `config.toml`.
 - Or by writing a newline separated list to a file and passing its path to rustypaste via `AUTH_TOKENS_FILE` and `DELETE_TOKENS_FILE` respectively.

--- a/README.md
+++ b/README.md
@@ -289,7 +289,10 @@ $ rustypaste
 
 You can also set multiple auth tokens via the array field `[server].auth_tokens` in your `config.toml`.
 
-> If neither `AUTH_TOKEN` nor `[server].auth_tokens` are set, the server will not require any authentication.
+- Via the array field `[server].auth_tokens` in your `config.toml`.
+- Or by writing a newline separated list to a file and passing its path to rustypaste via `AUTH_TOKENS_FILE` and `DELETE_TOKENS_FILE` respectively.
+
+> If neither `AUTH_TOKEN`, `AUTH_TOKENS_FILE` nor `[server].auth_tokens` are set, the server will not require any authentication.
 >
 > Exception is the `DELETE` endpoint, which requires at least one token to be set. See [deleting files from server](#delete-file-from-server) for more information.
 

--- a/fixtures/README.md
+++ b/fixtures/README.md
@@ -7,7 +7,7 @@ This directory contains the [test fixtures](https://en.wikipedia.org/wiki/Test_f
 1. Build the project in debug mode: `cargo build`
 2. Execute the runner script in this directory: `./test-fixtures.sh`
 
-On `macOS` you need to have [coreutils](https://www.gnu.org/software/coreutils/) installed to run the script. 
+On `macOS` you need to have [coreutils](https://www.gnu.org/software/coreutils/) installed to run the script.
 The simplest way is to install it via [Homebrew](https://brew.sh/): `brew install coreutils`
 
 ### Adding new fixtures
@@ -27,6 +27,11 @@ test-file-upload/
 
 ```sh
 #!/usr/bin/env bash
+
+# Optional
+custom_env() {
+  # setting environment variables such as AUTH_TOKEN or AUTH_FILE
+}
 
 setup() {
   # preparation

--- a/fixtures/README.md
+++ b/fixtures/README.md
@@ -30,7 +30,7 @@ test-file-upload/
 
 # Optional
 custom_env() {
-  # setting environment variables such as AUTH_TOKEN or AUTH_FILE
+  # setting environment variables such as AUTH_TOKEN or AUTH_TOKENS_FILE
 }
 
 setup() {

--- a/fixtures/test-expiring-file-upload/test.sh
+++ b/fixtures/test-expiring-file-upload/test.sh
@@ -3,13 +3,13 @@
 content="test data"
 
 setup() {
-  echo "$content" > file
+  echo "$content" >file
 }
 
 run_test() {
   file_url=$(curl -s -F "file=@file" -H "expire:1s" localhost:8000)
   test "$content" = "$(cat upload/file.txt.*)"
-  sleep 2
+  sleep 3
 
   result="$(curl -s $file_url)"
   test "file is not found or expired :(" = "$result"

--- a/fixtures/test-fixtures.sh
+++ b/fixtures/test-fixtures.sh
@@ -9,11 +9,13 @@ NC='\033[0m'
 run_fixture() {
   cd "$FIXTURE_DIR/$1" || exit 1
   source "test.sh"
+  type custom_env &>/dev/null && custom_env
   NO_COLOR=1 CONFIG=config.toml "$PROJECT_DIR/target/debug/rustypaste" &
   SERVER_PID=$!
   trap 'kill -9 "$SERVER_PID" && wait "$SERVER_PID" 2> /dev/null' RETURN
   sleep 1
-  ( set -e;
+  (
+    set -e
     setup
     run_test
     teardown
@@ -24,7 +26,9 @@ run_fixture() {
 
 main() {
   find * -maxdepth 0 -type d -print0 | while IFS= read -r -d '' fixture; do
-    run_fixture "$fixture"
+    # Since we are creating a subshell, all environment variables created by custom_env will be lost
+    # Return code is preserved
+    (run_fixture "$fixture")
     exit_status=$?
     if [ "$exit_status" -eq 0 ]; then
       echo -e "[${GREEN}ok${NC}] $fixture"

--- a/fixtures/test-server-auth-token-file/auth_file
+++ b/fixtures/test-server-auth-token-file/auth_file
@@ -1,0 +1,4 @@
+bread
+brioche
+baguette
+naan

--- a/fixtures/test-server-auth-token-file/config.toml
+++ b/fixtures/test-server-auth-token-file/config.toml
@@ -1,0 +1,8 @@
+[server]
+address = "127.0.0.1:8000"
+max_content_length = "10MB"
+upload_path = "./upload"
+
+[paste]
+default_extension = "txt"
+duplicate_files = false

--- a/fixtures/test-server-auth-token-file/test.sh
+++ b/fixtures/test-server-auth-token-file/test.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+content1="test data"
+content2="other test"
+
+custom_env() {
+  export AUTH_TOKENS_FILE=./auth_file
+}
+
+setup() {
+  echo "$content1" >file1
+  echo "$content2" >file2
+}
+
+run_test() {
+  file_url=$(curl -s -F "file=@file1" -H "Authorization: bread" localhost:8000)
+  test "$content1" = "$(cat upload/file1.txt)"
+  sleep 2
+
+  result="$(curl -s $file_url)"
+  test "$content1" = "$result"
+
+  file_url=$(curl -s -F "file=@file2" -H "Authorization: naan" localhost:8000)
+  test "$content2" = "$(cat upload/file2.txt)"
+  sleep 2
+
+  result="$(curl -s $file_url)"
+  test "$content2" = "$result"
+
+  result=$(curl -s -F "file=@file2" -H "Authorization: tomato" localhost:8000)
+  test "$result" = "unauthorized"
+}
+
+teardown() {
+  rm file1
+  rm file2
+  rm -r upload
+}

--- a/fixtures/test-server-delete-token-file/config.toml
+++ b/fixtures/test-server-delete-token-file/config.toml
@@ -1,0 +1,8 @@
+[server]
+address = "127.0.0.1:8000"
+max_content_length = "10MB"
+upload_path = "./upload"
+
+[paste]
+default_extension = "txt"
+duplicate_files = false

--- a/fixtures/test-server-delete-token-file/delete_file
+++ b/fixtures/test-server-delete-token-file/delete_file
@@ -1,0 +1,4 @@
+bread
+brioche
+baguette
+naan

--- a/fixtures/test-server-delete-token-file/test.sh
+++ b/fixtures/test-server-delete-token-file/test.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+content1="test data"
+del_resp="file deleted"
+
+custom_env() {
+  export DELETE_TOKENS_FILE=./delete_file
+}
+
+setup() {
+  echo "$content" >file
+}
+
+run_test() {
+  file_url=$(curl -s -F "file=@file" localhost:8000)
+  test "$del_rep"="$(curl -s -H "Authorization: naan" -X DELETE $file_url)"
+
+  sleep 2
+  file_url=$(curl -s -F "file=@file" localhost:8000)
+  test "$del_re"="$(curl -s -H "Authorization: bread" -X DELETE $file_url)"
+
+  file_url=$(curl -s -F "file=@file" localhost:8000)
+  test "unauthorized"=$(curl -s -H "Authorization: tomato" -X DELETE $file_url)
+}
+
+teardown() {
+  rm file
+  rm -r upload
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,5 +41,11 @@ pub const CONFIG_ENV: &str = "CONFIG";
 /// Environment variable for setting the authentication token.
 pub const AUTH_TOKEN_ENV: &str = "AUTH_TOKEN";
 
+/// Environment variable for the path to a file containing multiple authentication token.
+pub const AUTH_TOKENS_FILE_ENV: &str = "AUTH_TOKENS_FILE";
+
 /// Environment variable for setting the deletion token.
 pub const DELETE_TOKEN_ENV: &str = "DELETE_TOKEN";
+
+/// Environment variable for the path to a file containing multiple deletion token.
+pub const DELETE_TOKENS_FILE_ENV: &str = "DELETE_TOKENS_FILE";


### PR DESCRIPTION
<!--- Thank you for contributing to rustypaste! -->

## Description

Add support for reading a list of newline separated tokens from a file
which path is being supplied through the following environment
variables:

- AUTH_FILE
- DELETE_FILE

Also add support for setting environment variables inside of fixtures through the optional `custom_env` function.

Also describe this new functionality in the readme.

<!--- Describe your changes in detail -->

## Motivation and Context

Need a way to supply multiple auth token akin to `AUTH_TOKEN` due to agenix behaviour.

closes #338

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Added UTs for file content parsing. File reading has not received any UT, but has been manually tested.

## Changelog Entry

<!--- Please write the changelog entry for these changes. -->
<!--- Follow the <https://keepachangelog.com/en/1.0.0/> format. -->
<!--- Use one of the Added, Changed, Deprecated, Removed, Fixed, and Security headers accordingly. -->
<!-- For example:
````
### Added

- Add a middleware for checking the content length
  - Before, the upload size was checked after full upload which was clearly wrong.
````
-->

### Added

- Multiple authentication and deletion token parsing via a file to which `AUTH_FILE` and `DELETION_FILE` point. This file needs to be a newline separated list of strings. Whitespace is discarded.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
