### PR TITLE
chore(ci): switch to macOS 14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
           - name: Linux
             runner: ubuntu-22.04
           - name: macOS
-            runner: macos-12
+            runner: macos-14
     name: Test fixtures [${{ matrix.os.name }}]
     runs-on: ${{ matrix.os.runner }}
     steps:


### PR DESCRIPTION
Trying to get rid of deprecation notices in CI.
