### PR TITLE
feat(server): allow named url shortening (#40)

### DIFF
--- a/fixtures/test-url-upload-override-filename/config.toml
+++ b/fixtures/test-url-upload-override-filename/config.toml
@@ -1,0 +1,8 @@
+[server]
+address = "127.0.0.1:8000"
+max_content_length = "10MB"
+upload_path = "./upload"
+
+[paste]
+default_extension = "txt"
+duplicate_files = true

--- a/fixtures/test-url-upload-override-filename/test.sh
+++ b/fixtures/test-url-upload-override-filename/test.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+url="https://orhun.dev/"
+
+url2="https://orhun.dev/does/not/exist"
+
+setup() {
+  :;
+}
+
+run_test() {
+  curl -s -F "url=$url" -H "filename: abc" localhost:8000 > /dev/null
+  test "$url" = "$(cat upload/url/abc)"
+
+  curl -s -F "url=$url2" -H "filename: abc" localhost:8000 > /dev/null
+  test "$url2" = "$(cat upload/url/abc)"
+
+  curl -s -F "url=$url2" -H "filename: what-a-great-link" localhost:8000 > /dev/null
+  test "$url2" = "$(cat upload/url/what-a-great-link)"
+}
+
+teardown() {
+  rm -r upload
+}

--- a/src/server.rs
+++ b/src/server.rs
@@ -296,7 +296,7 @@ async fn upload(
                     let config = config
                         .read()
                         .map_err(|_| error::ErrorInternalServerError("cannot acquire config"))?;
-                    paste.store_url(expiry_date, &config)?
+                    paste.store_url(expiry_date, header_filename, &config)?
                 }
             };
             info!(


### PR DESCRIPTION
## Description

I ran the filename header through the URL shortening route

## Motivation and Context

This lets me use rustypaste to link to a specific link using a specified short name (for ergonomics).

Also fixes #40 by the by.

## How Has This Been Tested?

## Changelog Entry

```
### Added

- Enable naming shortened URLs beyond using a random string or the text "url"
````
-->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
