### PR TITLE
change: use fully locked system accounts

### DIFF
--- a/extra/systemd257+/rustypaste.sysusers
+++ b/extra/systemd257+/rustypaste.sysusers
@@ -1,0 +1,2 @@
+# use fully locked system account on systemd 257+ (note the !)
+u! rustypaste - "Minimal file upload/pastebin service" /var/lib/rustypaste


### PR DESCRIPTION
systemd v257 supports and recommends fully locked system accounts[1]

[1]: https://www.freedesktop.org/software/systemd/man/latest/sysusers.d.html#u

<!--- Thank you for contributing to rustypaste! -->

## Description

use fully locked system accounts

## Motivation and Context

Recommendation from systmd v257 and above
https://github.com/systemd/systemd/blob/25a306f6c4d9b8596e25d7771802f005ebae91ba/NEWS#L822-L832

## How Has This Been Tested?

Not tested as this is downstream

## Changelog Entry

<!--- Please write the changelog entry for these changes. -->
<!--- Follow the <https://keepachangelog.com/en/1.0.0/> format. -->
<!--- Use one of the Added, Changed, Deprecated, Removed, Fixed, and Security headers accordingly. -->
<!-- For example:
````
### Added

- Add a middleware for checking the content length
  - Before, the upload size was checked after full upload which was clearly wrong.
````
-->
### Changed
- use fully locked sytem acounts on systemd > v257


## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [ ] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [ ] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
