### PR TITLE
fix(lints): len() can be called directly on strings

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -472,7 +472,7 @@ mod tests {
 
     async fn assert_body(body: BoxBody, expected: &str) -> Result<(), Error> {
         if let BodySize::Sized(size) = body.size() {
-            assert_eq!(size, expected.as_bytes().len() as u64);
+            assert_eq!(size, expected.len() as u64);
             let body_bytes = actix_web::body::to_bytes(body).await?;
             let body_text = str::from_utf8(&body_bytes)?;
             assert_eq!(expected, body_text);


### PR DESCRIPTION
Fixes the following error in pipeline:

```
error: needless call to `as_bytes()`
   --> src/server.rs:475:30
    |
475 |             assert_eq!(size, expected.as_bytes().len() as u64);
    |                              ^^^^^^^^^^^^^^^^^^^^^^^^^ help: `len()` can be called directly on strings: `expected.len()`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_as_bytes
    = note: `-D clippy::needless-as-bytes` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::needless_as_bytes)]`

error: could not compile `rustypaste` (lib test) due to 1 previous error
```
