### PR TITLE
chore(deps): bump rand to 0.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,7 +73,7 @@ dependencies = [
  "mime",
  "percent-encoding",
  "pin-project-lite",
- "rand",
+ "rand 0.8.5",
  "sha1",
  "smallvec",
  "tokio",
@@ -109,7 +109,7 @@ dependencies = [
  "log",
  "memchr",
  "mime",
- "rand",
+ "rand 0.8.5",
  "serde",
  "serde_json",
  "serde_plain",
@@ -303,7 +303,7 @@ version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.12",
  "once_cell",
  "version_check",
 ]
@@ -315,10 +315,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.12",
  "once_cell",
  "version_check",
- "zerocopy",
+ "zerocopy 0.7.32",
 ]
 
 [[package]]
@@ -402,7 +402,7 @@ dependencies = [
  "openssl",
  "percent-encoding",
  "pin-project-lite",
- "rand",
+ "rand 0.8.5",
  "rustls",
  "serde",
  "serde_json",
@@ -911,7 +911,19 @@ checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.13.3+wasi-0.2.2",
+ "windows-targets 0.52.4",
 ]
 
 [[package]]
@@ -1411,7 +1423,7 @@ checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
 dependencies = [
  "libc",
  "log",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.48.0",
 ]
 
@@ -1423,7 +1435,7 @@ checksum = "4569e456d394deccd22ce1c1913e6ea0e54519f577285001215d33557431afe4"
 dependencies = [
  "hermit-abi",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
 ]
 
@@ -1606,7 +1618,7 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -1734,8 +1746,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.0",
+ "zerocopy 0.8.14",
 ]
 
 [[package]]
@@ -1745,7 +1768,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.0",
 ]
 
 [[package]]
@@ -1754,7 +1787,17 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.12",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b08f3c9802962f7e1b25113931d94f43ed9725bebc59db9d0c3e9a23b67e15ff"
+dependencies = [
+ "getrandom 0.3.1",
+ "zerocopy 0.8.14",
 ]
 
 [[package]]
@@ -1833,7 +1876,7 @@ checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.12",
  "libc",
  "spin",
  "untrusted",
@@ -1879,7 +1922,7 @@ dependencies = [
  "borsh",
  "bytes",
  "num-traits",
- "rand",
+ "rand 0.8.5",
  "rkyv",
  "serde",
  "serde_json",
@@ -1958,7 +2001,7 @@ dependencies = [
  "mime",
  "path-clean",
  "petname",
- "rand",
+ "rand 0.9.0",
  "regex",
  "ring",
  "serde",
@@ -2560,6 +2603,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
+name = "wasi"
+version = "0.13.3+wasi-0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2"
+dependencies = [
+ "wit-bindgen-rt",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "0.25.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2747,6 +2799,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "wit-bindgen-rt"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
+dependencies = [
+ "bitflags 2.5.0",
+]
+
+[[package]]
 name = "write16"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2808,7 +2869,16 @@ version = "0.7.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be"
 dependencies = [
- "zerocopy-derive",
+ "zerocopy-derive 0.7.32",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a367f292d93d4eab890745e75a778da40909cab4d6ff8173693812f79c4a2468"
+dependencies = [
+ "zerocopy-derive 0.8.14",
 ]
 
 [[package]]
@@ -2816,6 +2886,17 @@ name = "zerocopy-derive"
 version = "0.7.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.82",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3931cb58c62c13adec22e38686b559c86a30565e16ad6e8510a337cedc611e1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ petname = { version = "2.0.2", default-features = false, features = [
   "default-rng",
   "default-words",
 ] }
-rand = "0.8.5"
+rand = "0.9.0"
 dotenvy = "0.15.7"
 url = "2.5.4"
 mime = "0.3.17"

--- a/src/random.rs
+++ b/src/random.rs
@@ -1,5 +1,5 @@
 use petname::Generator;
-use rand::{distributions::Alphanumeric, Rng};
+use rand::{distr::Alphanumeric, Rng};
 
 /// Random URL configuration.
 #[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
@@ -32,7 +32,7 @@ impl RandomURLConfig {
                 self.words.unwrap_or(2),
                 self.separator.as_deref().unwrap_or("-"),
             )?,
-            RandomURLType::Alphanumeric => rand::thread_rng()
+            RandomURLType::Alphanumeric => rand::rng()
                 .sample_iter(&Alphanumeric)
                 .take(self.length.unwrap_or(8))
                 .map(char::from)


### PR DESCRIPTION
0.9.0 introduced several (breaking) changes (only listing relevant ones for this change):

- Rename module rand::distributions to rand::distr
- Rename fn rand::thread_rng() to rand::rng() and remove from the prelude
- Deprecate thread_rng()

----

Bumps [rand](https://github.com/rust-random/rand) from 0.8.5 to 0.9.0.
<details>
<summary>Changelog</summary>
<p><em>Sourced from <a href="https://github.com/rust-random/rand/blob/master/CHANGELOG.md">rand's changelog</a>.</em></p>
<blockquote>
<h2>[0.9.0] - 2025-01-27</h2>
<h3>Security and unsafe</h3>
<ul>
<li>Policy: &quot;rand is not a crypto library&quot; (<a href="https://redirect.github.com/rust-random/rand/issues/1514">#1514</a>)</li>
<li>Remove fork-protection from <code>ReseedingRng</code> and <code>ThreadRng</code>. Instead, it is recommended to call <code>ThreadRng::reseed</code> on fork. (<a href="https://redirect.github.com/rust-random/rand/issues/1379">#1379</a>)</li>
<li>Use <code>zerocopy</code> to replace some <code>unsafe</code> code (<a href="https://redirect.github.com/rust-random/rand/issues/1349">#1349</a>, <a href="https://redirect.github.com/rust-random/rand/issues/1393">#1393</a>, <a href="https://redirect.github.com/rust-random/rand/issues/1446">#1446</a>, <a href="https://redirect.github.com/rust-random/rand/issues/1502">#1502</a>)</li>
</ul>
<h3>Dependencies</h3>
<ul>
<li>Bump the MSRV to 1.63.0 (<a href="https://redirect.github.com/rust-random/rand/issues/1207">#1207</a>, <a href="https://redirect.github.com/rust-random/rand/issues/1246">#1246</a>, <a href="https://redirect.github.com/rust-random/rand/issues/1269">#1269</a>, <a href="https://redirect.github.com/rust-random/rand/issues/1341">#1341</a>, <a href="https://redirect.github.com/rust-random/rand/issues/1416">#1416</a>, <a href="https://redirect.github.com/rust-random/rand/issues/1536">#1536</a>); note that 1.60.0 may work for dependents when using <code>--ignore-rust-version</code></li>
<li>Update to <code>rand_core</code> v0.9.0 (<a href="https://redirect.github.com/rust-random/rand/issues/1558">#1558</a>)</li>
</ul>
<h3>Features</h3>
<ul>
<li>Support <code>std</code> feature without <code>getrandom</code> or <code>rand_chacha</code> (<a href="https://redirect.github.com/rust-random/rand/issues/1354">#1354</a>)</li>
<li>Enable feature <code>small_rng</code> by default (<a href="https://redirect.github.com/rust-random/rand/issues/1455">#1455</a>)</li>
<li>Remove implicit feature <code>rand_chacha</code>; use <code>std_rng</code> instead. (<a href="https://redirect.github.com/rust-random/rand/issues/1473">#1473</a>)</li>
<li>Rename feature <code>serde1</code> to <code>serde</code> (<a href="https://redirect.github.com/rust-random/rand/issues/1477">#1477</a>)</li>
<li>Rename feature <code>getrandom</code> to <code>os_rng</code> (<a href="https://redirect.github.com/rust-random/rand/issues/1537">#1537</a>)</li>
<li>Add feature <code>thread_rng</code> (<a href="https://redirect.github.com/rust-random/rand/issues/1547">#1547</a>)</li>
</ul>
<h3>API changes: rand_core traits</h3>
<ul>
<li>Add fn <code>RngCore::read_adapter</code> implementing <code>std::io::Read</code> (<a href="https://redirect.github.com/rust-random/rand/issues/1267">#1267</a>)</li>
<li>Add trait <code>CryptoBlockRng: BlockRngCore</code>; make <code>trait CryptoRng: RngCore</code> (<a href="https://redirect.github.com/rust-random/rand/issues/1273">#1273</a>)</li>
<li>Add traits <code>TryRngCore</code>, <code>TryCryptoRng</code> (<a href="https://redirect.github.com/rust-random/rand/issues/1424">#1424</a>, <a href="https://redirect.github.com/rust-random/rand/issues/1499">#1499</a>)</li>
<li>Rename <code>fn SeedableRng::from_rng</code> -&gt; <code>try_from_rng</code> and add infallible variant <code>fn from_rng</code> (<a href="https://redirect.github.com/rust-random/rand/issues/1424">#1424</a>)</li>
<li>Rename <code>fn SeedableRng::from_entropy</code> -&gt; <code>from_os_rng</code> and add fallible variant <code>fn try_from_os_rng</code> (<a href="https://redirect.github.com/rust-random/rand/issues/1424">#1424</a>)</li>
<li>Add bounds <code>Clone</code> and <code>AsRef</code> to associated type <code>SeedableRng::Seed</code> (<a href="https://redirect.github.com/rust-random/rand/issues/1491">#1491</a>)</li>
</ul>
<h3>API changes: Rng trait and top-level fns</h3>
<ul>
<li>Rename fn <code>rand::thread_rng()</code> to <code>rand::rng()</code> and remove from the prelude (<a href="https://redirect.github.com/rust-random/rand/issues/1506">#1506</a>)</li>
<li>Remove fn <code>rand::random()</code> from the prelude (<a href="https://redirect.github.com/rust-random/rand/issues/1506">#1506</a>)</li>
<li>Add top-level fns <code>random_iter</code>, <code>random_range</code>, <code>random_bool</code>, <code>random_ratio</code>, <code>fill</code> (<a href="https://redirect.github.com/rust-random/rand/issues/1488">#1488</a>)</li>
<li>Re-introduce fn <code>Rng::gen_iter</code> as <code>random_iter</code> (<a href="https://redirect.github.com/rust-random/rand/issues/1305">#1305</a>, <a href="https://redirect.github.com/rust-random/rand/issues/1500">#1500</a>)</li>
<li>Rename fn <code>Rng::gen</code> to <code>random</code> to avoid conflict with the new <code>gen</code> keyword in Rust 2024 (<a href="https://redirect.github.com/rust-random/rand/issues/1438">#1438</a>)</li>
<li>Rename fns <code>Rng::gen_range</code> to <code>random_range</code>, <code>gen_bool</code> to <code>random_bool</code>, <code>gen_ratio</code> to <code>random_ratio</code> (<a href="https://redirect.github.com/rust-random/rand/issues/1505">#1505</a>)</li>
<li>Annotate panicking methods with <code>#[track_caller]</code> (<a href="https://redirect.github.com/rust-random/rand/issues/1442">#1442</a>, <a href="https://redirect.github.com/rust-random/rand/issues/1447">#1447</a>)</li>
</ul>
<h3>API changes: RNGs</h3>
<ul>
<li>Fix <code>&lt;SmallRng as SeedableRng&gt;::Seed</code> size to 256 bits (<a href="https://redirect.github.com/rust-random/rand/issues/1455">#1455</a>)</li>
<li>Remove first parameter (<code>rng</code>) of <code>ReseedingRng::new</code> (<a href="https://redirect.github.com/rust-random/rand/issues/1533">#1533</a>)</li>
</ul>
<h3>API changes: Sequences</h3>
<ul>
<li>Split trait <code>SliceRandom</code> into <code>IndexedRandom</code>, <code>IndexedMutRandom</code>, <code>SliceRandom</code> (<a href="https://redirect.github.com/rust-random/rand/issues/1382">#1382</a>)</li>
<li>Add <code>IndexedRandom::choose_multiple_array</code>, <code>index::sample_array</code> (<a href="https://redirect.github.com/rust-random/rand/issues/1453">#1453</a>, <a href="https://redirect.github.com/rust-random/rand/issues/1469">#1469</a>)</li>
</ul>
<h3>API changes: Distributions: renames</h3>
<ul>
<li>Rename module <code>rand::distributions</code> to <code>rand::distr</code> (<a href="https://redirect.github.com/rust-random/rand/issues/1470">#1470</a>)</li>
<li>Rename distribution <code>Standard</code> to <code>StandardUniform</code> (<a href="https://redirect.github.com/rust-random/rand/issues/1526">#1526</a>)</li>
<li>Move <code>distr::Slice</code> -&gt; <code>distr::slice::Choose</code>, <code>distr::EmptySlice</code> -&gt; <code>distr::slice::Empty</code> (<a href="https://redirect.github.com/rust-random/rand/issues/1548">#1548</a>)</li>
<li>Rename trait <code>distr::DistString</code> -&gt; <code>distr::SampleString</code> (<a href="https://redirect.github.com/rust-random/rand/issues/1548">#1548</a>)</li>
<li>Rename <code>distr::DistIter</code> -&gt; <code>distr::Iter</code>, <code>distr::DistMap</code> -&gt; <code>distr::Map</code> (<a href="https://redirect.github.com/rust-random/rand/issues/1548">#1548</a>)</li>
</ul>
<!-- raw HTML omitted -->
</blockquote>
<p>... (truncated)</p>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/rust-random/rand/commit/96f8df65ee6b4368d91a006f9c5b4a8050abae49"><code>96f8df6</code></a> Prepare 0.9.0 release (<a href="https://redirect.github.com/rust-random/rand/issues/1558">#1558</a>)</li>
<li><a href="https://github.com/rust-random/rand/commit/34da3214df7de717cb27b4e1527ed971f47de311"><code>34da321</code></a> Enable <code>stdarch_x86_avx512</code> for cpu has <code>avx512bw</code> (<a href="https://redirect.github.com/rust-random/rand/issues/1551">#1551</a>)</li>
<li><a href="https://github.com/rust-random/rand/commit/b4b1eb7579c0a47c1d71560ada0acffd647c9370"><code>b4b1eb7</code></a> Re-org with distr::slice, distr::weighted modules (<a href="https://redirect.github.com/rust-random/rand/issues/1548">#1548</a>)</li>
<li><a href="https://github.com/rust-random/rand/commit/16eb7de94a124e84c11b0cb236c8dc798fe5cd25"><code>16eb7de</code></a> Add the <code>thread_rng</code> feature flag (<a href="https://redirect.github.com/rust-random/rand/issues/1547">#1547</a>)</li>
<li><a href="https://github.com/rust-random/rand/commit/afa24e49b418fb06d8f030b15636f12814ce13a5"><code>afa24e4</code></a> Fix test status badges (<a href="https://redirect.github.com/rust-random/rand/issues/1544">#1544</a>)</li>
<li><a href="https://github.com/rust-random/rand/commit/c681dfc345b3f24852a3931d3ba3adda2356336d"><code>c681dfc</code></a> Create FUNDING.yml</li>
<li><a href="https://github.com/rust-random/rand/commit/9f05e22afb6031d32f36cd927592e7e49b668d64"><code>9f05e22</code></a> Update: getrandom v0.3.0 rc.0 (<a href="https://redirect.github.com/rust-random/rand/issues/1541">#1541</a>)</li>
<li><a href="https://github.com/rust-random/rand/commit/88c310b18939a12f407c659bdd66554677d8b8c1"><code>88c310b</code></a> Fix docs.rs build options (<a href="https://redirect.github.com/rust-random/rand/issues/1539">#1539</a>)</li>
<li><a href="https://github.com/rust-random/rand/commit/b879689a6078a9d4a8d24319572b0f02662fb315"><code>b879689</code></a> Adjust GH Actions (<a href="https://redirect.github.com/rust-random/rand/issues/1538">#1538</a>)</li>
<li><a href="https://github.com/rust-random/rand/commit/3fac49fe890da599d671f2ad02074f4961480878"><code>3fac49f</code></a> Prepare 0.9.0-beta.0 (<a href="https://redirect.github.com/rust-random/rand/issues/1535">#1535</a>)</li>
<li>Additional commits viewable in <a href="https://github.com/rust-random/rand/compare/0.8.5...0.9.0">compare view</a></li>
</ul>
</details>
<br />

