### PR TITLE
refactor: prepare for rust edition 2024

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -243,7 +243,9 @@ mod tests {
     #[test]
     fn test_parse_config() -> Result<(), ConfigError> {
         let config_path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("config.toml");
-        env::set_var("SERVER__ADDRESS", "0.0.1.1");
+        unsafe {
+            env::set_var("SERVER__ADDRESS", "0.0.1.1");
+        }
         let config = Config::parse(&config_path)?;
         assert_eq!("0.0.1.1", config.server.address);
         Ok(())
@@ -253,7 +255,9 @@ mod tests {
     #[allow(deprecated)]
     fn test_parse_deprecated_config() -> Result<(), ConfigError> {
         let config_path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("config.toml");
-        env::set_var("SERVER__ADDRESS", "0.0.1.1");
+        unsafe {
+            env::set_var("SERVER__ADDRESS", "0.0.1.1");
+        }
         let mut config = Config::parse(&config_path)?;
         config.paste.random_url = Some(RandomURLConfig {
             enabled: Some(true),
@@ -276,8 +280,10 @@ mod tests {
     #[test]
     fn test_get_tokens() -> Result<(), ConfigError> {
         let config_path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("config.toml");
-        env::set_var("AUTH_TOKEN", "env_auth");
-        env::set_var("DELETE_TOKEN", "env_delete");
+        unsafe {
+            env::set_var("AUTH_TOKEN", "env_auth");
+            env::set_var("DELETE_TOKEN", "env_delete");
+        }
         let mut config = Config::parse(&config_path)?;
         // empty tokens will be filtered
         config.server.auth_tokens =
@@ -297,8 +303,10 @@ mod tests {
             ])),
             config.get_tokens(TokenType::Delete)
         );
-        env::remove_var("AUTH_TOKEN");
-        env::remove_var("DELETE_TOKEN");
+        unsafe {
+            env::remove_var("AUTH_TOKEN");
+            env::remove_var("DELETE_TOKEN");
+        }
 
         // `get_tokens` returns `None` if no tokens are configured
         config.server.auth_tokens = Some(["  ".to_string()].into());

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,7 +48,9 @@ fn setup(config_folder: &Path) -> IoResult<(Data<RwLock<Config>>, ServerConfig, 
     // Parse configuration.
     let config_path = match env::var(CONFIG_ENV).ok() {
         Some(path) => {
-            env::remove_var(CONFIG_ENV);
+            unsafe {
+                env::remove_var(CONFIG_ENV);
+            }
             PathBuf::from(path)
         }
         None => config_folder.join("config.toml"),


### PR DESCRIPTION
<!--- Thank you for contributing to rustypaste! -->

## Description

Use `unsafe` blocks where required by edition 2024.

## Motivation and Context

Edition 2024 requires setting and removing env vars to be in an `unsafe` block.
When switching to edition 2024 in the future, a `cargo fmt` will be required as well.

## How Has This Been Tested?

cargo test
fixtures

## Changelog Entry

<!--- Please write the changelog entry for these changes. -->
<!--- Follow the <https://keepachangelog.com/en/1.0.0/> format. -->
<!--- Use one of the Added, Changed, Deprecated, Removed, Fixed, and Security headers accordingly. -->
<!-- For example:
````
### Added

- Add a middleware for checking the content length
  - Before, the upload size was checked after full upload which was clearly wrong.
````
-->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [x] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
