### PR TITLE
ci(lychee): add `.lycheeignore` with new links

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,6 @@ jobs:
       - name: Check the links
         uses: lycheeverse/lychee-action@v2
         with:
-          args: --exclude "example.com|site.com|localhost|awesome.txt|x.txt" -v *.md
+          args: --exclude 'example\.com|site\.com|repology\.org|localhost|awesome\.txt|x\.txt' -v *.md
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,6 @@ jobs:
       - name: Check the links
         uses: lycheeverse/lychee-action@v2
         with:
-          args: --exclude 'example\.com|site\.com|repology\.org|localhost|awesome\.txt|x\.txt' -v *.md
+          args: -v *.md
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,0 +1,9 @@
+# Example and local links
+example\.com
+site\.com
+localhost
+awesome\.txt
+x\.txt
+# Links that sometimes timeout (e.g. due to rate limiting, ...), but we know that they are valid.
+https://repology.org/badge/vertical-allrepos/rustypaste.svg
+https://repology.org/project/rustypaste/versions


### PR DESCRIPTION
For a while now, 2 links run into a timeout sporadically. I've exluded `repology.org` from the check.

```
[TIMEOUT] https://repology.org/badge/vertical-allrepos/rustypaste.svg | Timeout
[TIMEOUT] https://repology.org/project/rustypaste/versions | Timeout
```

Additionally according to the lychee documentation the exclude argument should be enclosed in single quotes.
I have also escaped the `.`, since we are using a regex.

We could also use a `.lycheeignore` file. e.g. it would make it easier to add complete links to that file, than changing the ci workflow file.