### PR TITLE
chore(cliff): fix heading level for new contributors

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -35,15 +35,14 @@ body = """
 {% endfor %}
 
 {%- if github.contributors | filter(attribute="is_first_time", value=true) | length != 0 %}
-  ## New Contributors
+    ### New Contributors
 {%- endif -%}
-
 {% for contributor in github.contributors | filter(attribute="is_first_time", value=true) %}
-  * @{{ contributor.username }} made their first contribution
-    {%- if contributor.pr_number %} in \
-      [#{{ contributor.pr_number }}]({{ self::remote_url() }}/pull/{{ contributor.pr_number }}) \
-    {%- endif %}
-{%- endfor %}\n
+        - @{{ contributor.username }} made their first contribution
+            {%- if contributor.pr_number %} in \
+            [#{{ contributor.pr_number }}]({{ self::remote_url() }}/pull/{{ contributor.pr_number }}) \
+            {%- endif %}
+{%- endfor %}\n\n
 """
 # template for the changelog footer
 footer = """


### PR DESCRIPTION
The current template adds `New Contributors` on the same level as the release. It should be on the same level as `Added`, `Changed`, ... It also uses `*` as the list character.
Additionally there is no empty line between the contributors and the release version. 

I've changed the level and used `-` as the list character for consistency. I've also added an empty line for better reading.

```markdown
### New Contributors
- @Narayanbhat166 made their first contribution
- @Vaelatern made their first contribution
- @nydragon made their first contribution
```

@orhun maybe you can have a look at the following issues, since you are the git-cliff expert 😉:

1. I wasn't able to fix 2 empty lines when there are no new contributors. But it's still better readable than no empty line if there are new contributors.

2. The `in [#XXX](link)` text is not generated. Although this has nothing to do with my change. It didn't work before either.

3. The "new contributor" entries are only generated on the master branch. They are not generated when I run `git-cliff` in my `fix/git-cliff-template` branch.