### PR TITLE
fix(fixtures): script and one test

### DIFF
--- a/fixtures/test-fixtures.sh
+++ b/fixtures/test-fixtures.sh
@@ -41,14 +41,16 @@ process_fixture() {
 
 main() {
   # If arguments are passed, run only those fixtures
-  [ $# -ne 0 ] && for fixture in "$@"; do
-    process_fixture "$fixture"
-  done && exit 0
-
+  if [ $# -ne 0 ]; then
+    for fixture in "$@"; do
+      process_fixture "$fixture"
+    done
+  else
   # Otherwise, run all fixtures
-  find * -maxdepth 0 -type d -print0 | while IFS= read -r -d '' fixture; do
-    process_fixture "$fixture"
-  done
+    find * -maxdepth 0 -type d -print0 | while IFS= read -r -d '' fixture; do
+      process_fixture "$fixture"
+    done
+  fi
 }
 
 [ "$DEBUG" == 'true' ] && set -x && export RUST_LOG=debug

--- a/fixtures/test-server-upload-dir-limit/test.sh
+++ b/fixtures/test-server-upload-dir-limit/test.sh
@@ -1,19 +1,19 @@
 #!/usr/bin/env bash
 
 setup() {
-  truncate -s 9KB bigfile1 bigfile2 bigfile3
+  truncate -s 9000 bigfile1 bigfile2 bigfile3
 }
 
 run_test() {
   result=$(curl -s -F "file=@bigfile1" localhost:8000)
   result=$(curl -s -F "file=@bigfile2" localhost:8000)
-  curl -s "$result"
+  content=$(curl -s "$result" &>/dev/null)
 
   result=$(curl -s -F "file=@bigfile3" localhost:8000)
   test "upload directory size limit exceeded" = "$result"
 }
 
 teardown() {
-  rm bigfile* 
+  rm bigfile*
   rm -r upload
 }


### PR DESCRIPTION
If the `test-fixtures.sh` script uses an argument, the test will always pass no matter what.
This change fixes the issue.

Additionally, the `test-server-upload-dir-limit` failed for multiple reasons:

- truncate on macOS does not understand `KB`
- curl returns an exit code 23 if you try to output a binary file to the terminal
- bash prints a warning if it encounters a null byte (this does not fail the test, but is still annoying)

P.S.: I still do not understand how the upload_dir_limit test could have ever passed in the pipeline. 
