### PR TITLE
feat(server): no extension for random urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ some text
     - pet name (e.g. `capital-mosquito.txt`)
     - alphanumeric string (e.g. `yB84D2Dv.txt`)
     - random suffix (e.g. `file.MRV5as.tar.gz`)
+    - no extension
   - supports expiring links
     - auto-expiration of files (optional)
     - auto-deletion of expired files (optional)
@@ -266,6 +267,14 @@ The generation of a random filename can be overridden by sending a header called
 
 ```sh
 curl -F "file=@x.txt" -H "filename: <file_name>" "<server_address>"
+```
+
+#### No extension when using `random_url`
+
+Rustypaste adds the filename's extension to the url. This can be changed by setting `no_extension` to `true`:
+
+```toml
+random_url = { type = "alphanumeric", length = 8, no_extension = true }
 ```
 
 ### Server

--- a/README.md
+++ b/README.md
@@ -268,14 +268,6 @@ The generation of a random filename can be overridden by sending a header called
 curl -F "file=@x.txt" -H "filename: <file_name>" "<server_address>"
 ```
 
-#### No extension when using `random_url`
-
-Rustypaste adds the filename's extension to the url. This can be changed by setting `no_extension` to `true`:
-
-```toml
-random_url = { type = "alphanumeric", length = 8, no_extension = true }
-```
-
 ### Server
 
 To start the server:

--- a/README.md
+++ b/README.md
@@ -71,7 +71,6 @@ some text
     - pet name (e.g. `capital-mosquito.txt`)
     - alphanumeric string (e.g. `yB84D2Dv.txt`)
     - random suffix (e.g. `file.MRV5as.tar.gz`)
-    - no extension
   - supports expiring links
     - auto-expiration of files (optional)
     - auto-deletion of expired files (optional)

--- a/config.toml
+++ b/config.toml
@@ -49,6 +49,7 @@ content_type = "text/plain; charset=utf-8"
 [paste]
 random_url = { type = "petname", words = 2, separator = "-" }
 #random_url = { type = "alphanumeric", length = 8 }
+#random_url = { type = "alphanumeric", length = 8, no_extension = true }
 #random_url = { type = "alphanumeric", length = 6, suffix_mode = true }
 default_extension = "txt"
 mime_override = [

--- a/fixtures/test-file-upload-random-noext/config.toml
+++ b/fixtures/test-file-upload-random-noext/config.toml
@@ -1,0 +1,9 @@
+[server]
+address = "127.0.0.1:8000"
+max_content_length = "10MB"
+upload_path = "./upload"
+
+[paste]
+random_url = { type = "alphanumeric", length = "6", no_extension = true }
+default_extension = "txt"
+duplicate_files = true

--- a/fixtures/test-file-upload-random-noext/test.sh
+++ b/fixtures/test-file-upload-random-noext/test.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+content="test data"
+
+setup() {
+  echo "$content" > file.txt
+  echo "$content" > file
+}
+
+run_test() {
+  file_url1=$(curl -s -F "file=@file.txt" localhost:8000)
+  file_name1=$(echo $file_url1 |cut -d'/' -f4)
+  file_url2=$(curl -s -F "file=@file" localhost:8000)
+  file_name2=$(echo $file_url2 |cut -d'/' -f4)
+
+  test "${#file_name1}" = "6"
+  test "${#file_name2}" = "6"
+}
+
+teardown() {
+  rm file.txt file
+  rm -r upload
+}

--- a/src/paste.rs
+++ b/src/paste.rs
@@ -474,12 +474,7 @@ mod tests {
             data: vec![116, 101, 115, 115, 117, 115],
             type_: PasteType::File,
         };
-        let file_name = paste.store_file(
-            "filename.txt",
-            None,
-            None,
-            &config,
-        )?;
+        let file_name = paste.store_file("filename.txt", None, None, &config)?;
         assert_eq!("tessus", fs::read_to_string(&file_name)?);
         assert_eq!(8, file_name.len());
         fs::remove_file(file_name)?;

--- a/src/paste.rs
+++ b/src/paste.rs
@@ -182,11 +182,7 @@ impl Paste {
                     file_name = random_text;
                 }
             }
-            if let Some(no_ext) = random_url.no_extension {
-                if no_ext {
-                    no_extension = true;
-                }
-            }
+            no_extension = random_url.no_extension.unwrap_or(false);
         }
         path.set_file_name(file_name);
         if !no_extension {

--- a/src/paste.rs
+++ b/src/paste.rs
@@ -169,6 +169,7 @@ impl Paste {
                 .unwrap_or(&config.paste.default_extension)
                 .to_string()
         };
+        let mut no_extension = false;
         if let Some(random_url) = &config.paste.random_url {
             if let Some(random_text) = random_url.generate() {
                 if let Some(suffix_mode) = random_url.suffix_mode {
@@ -181,9 +182,16 @@ impl Paste {
                     file_name = random_text;
                 }
             }
+            if let Some(no_ext) = random_url.no_extension {
+                if no_ext {
+                    no_extension = true;
+                }
+            }
         }
         path.set_file_name(file_name);
-        path.set_extension(extension);
+        if !no_extension {
+            path.set_extension(extension);
+        }
         if let Some(header_filename) = header_filename {
             file_name = header_filename;
             path.set_file_name(file_name);
@@ -454,6 +462,26 @@ mod tests {
         )?;
         assert_eq!("tessus", fs::read_to_string(&file_name)?);
         assert_eq!("fn_from_header", file_name);
+        fs::remove_file(file_name)?;
+
+        config.paste.random_url = Some(RandomURLConfig {
+            length: Some(8),
+            type_: RandomURLType::Alphanumeric,
+            no_extension: Some(true),
+            ..RandomURLConfig::default()
+        });
+        let paste = Paste {
+            data: vec![116, 101, 115, 115, 117, 115],
+            type_: PasteType::File,
+        };
+        let file_name = paste.store_file(
+            "filename.txt",
+            None,
+            None,
+            &config,
+        )?;
+        assert_eq!("tessus", fs::read_to_string(&file_name)?);
+        assert_eq!(8, file_name.len());
         fs::remove_file(file_name)?;
 
         for paste_type in &[PasteType::Url, PasteType::Oneshot] {

--- a/src/random.rs
+++ b/src/random.rs
@@ -18,6 +18,8 @@ pub struct RandomURLConfig {
     pub type_: RandomURLType,
     /// Append a random string to the original filename.
     pub suffix_mode: Option<bool>,
+    /// Do not add or keep an extension.
+    pub no_extension: Option<bool>,
 }
 
 #[allow(deprecated)]


### PR DESCRIPTION
## Description

Rustypaste adds the filename's extension to the url. This can be changed by setting `no_extension` to `true`:

```toml
random_url = { type = "alphanumeric", length = 8, no_extension = true }
```

closes #437

## Motivation and Context

see #437

## How Has This Been Tested?

- cargo test
- fixtures
- manual tests

## Changelog Entry

<!--- Please write the changelog entry for these changes. -->
<!--- Follow the <https://keepachangelog.com/en/1.0.0/> format. -->
<!--- Use one of the Added, Changed, Deprecated, Removed, Fixed, and Security headers accordingly. -->

````
### Added

- Add option `no_extension` to `random_url` so that no extension is added to the random URL

```toml
random_url = { type = "alphanumeric", length = 8, no_extension = true }
```

````


## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
