### PR TITLE
fix(lints): apply clippy suggestions

### DIFF
--- a/src/paste.rs
+++ b/src/paste.rs
@@ -5,7 +5,7 @@ use crate::util;
 use actix_web::{error, Error};
 use awc::Client;
 use std::fs::{self, File};
-use std::io::{Error as IoError, ErrorKind as IoErrorKind, Result as IoResult, Write};
+use std::io::{Error as IoError, Result as IoResult, Write};
 use std::path::{Path, PathBuf};
 use std::str;
 use std::sync::RwLock;
@@ -198,7 +198,7 @@ impl Paste {
             .unwrap_or_default()
             .to_string();
         let file_path = util::glob_match_file(path.clone())
-            .map_err(|_| IoError::new(IoErrorKind::Other, String::from("path is not valid")))?;
+            .map_err(|_| IoError::other(String::from("path is not valid")))?;
         if file_path.is_file() && file_path.exists() {
             return Err(error::ErrorConflict("file already exists\n"));
         }
@@ -282,9 +282,8 @@ impl Paste {
         header_filename: Option<String>,
         config: &Config,
     ) -> IoResult<String> {
-        let data = str::from_utf8(&self.data)
-            .map_err(|e| IoError::new(IoErrorKind::Other, e.to_string()))?;
-        let url = Url::parse(data).map_err(|e| IoError::new(IoErrorKind::Other, e.to_string()))?;
+        let data = str::from_utf8(&self.data).map_err(|e| IoError::other(e.to_string()))?;
+        let url = Url::parse(data).map_err(|e| IoError::other(e.to_string()))?;
         let mut file_name = self.type_.get_dir();
         if let Some(random_url) = &config.paste.random_url {
             if let Some(random_text) = random_url.generate() {

--- a/src/util.rs
+++ b/src/util.rs
@@ -104,8 +104,7 @@ pub fn sha256_digest<R: Read>(input: R) -> Result<String, ActixError> {
         .collect::<Vec<&u8>>()
         .iter()
         .try_fold::<String, _, IoResult<String>>(String::new(), |mut output, b| {
-            write!(output, "{b:02x}")
-                .map_err(|e| IoError::new(IoErrorKind::Other, e.to_string()))?;
+            write!(output, "{b:02x}").map_err(|e| IoError::other(e.to_string()))?;
             Ok(output)
         })?)
 }


### PR DESCRIPTION
found by #446 

fixes:

```
warning: this can be `std::io::Error::other(_)`
   --> src/paste.rs:201:26
    |
201 |             .map_err(|_| IoError::new(IoErrorKind::Other, String::from("path is not valid")))?;
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#io_other_error
    = note: `#[warn(clippy::io_other_error)]` on by default
help: use `std::io::Error::other`
    |
201 -             .map_err(|_| IoError::new(IoErrorKind::Other, String::from("path is not valid")))?;
201 +             .map_err(|_| IoError::other(String::from("path is not valid")))?;
    |

warning: this can be `std::io::Error::other(_)`
   --> src/paste.rs:286:26
    |
286 |             .map_err(|e| IoError::new(IoErrorKind::Other, e.to_string()))?;
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#io_other_error
help: use `std::io::Error::other`
    |
286 -             .map_err(|e| IoError::new(IoErrorKind::Other, e.to_string()))?;
286 +             .map_err(|e| IoError::other(e.to_string()))?;
    |

warning: this can be `std::io::Error::other(_)`
   --> src/paste.rs:287:48
    |
287 |         let url = Url::parse(data).map_err(|e| IoError::new(IoErrorKind::Other, e.to_string()))?;
    |                                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#io_other_error
help: use `std::io::Error::other`
    |
287 -         let url = Url::parse(data).map_err(|e| IoError::new(IoErrorKind::Other, e.to_string()))?;
287 +         let url = Url::parse(data).map_err(|e| IoError::other(e.to_string()))?;
    |

warning: this can be `std::io::Error::other(_)`
   --> src/util.rs:108:30
    |
108 |                 .map_err(|e| IoError::new(IoErrorKind::Other, e.to_string()))?;
    |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#io_other_error
help: use `std::io::Error::other`
    |
108 -                 .map_err(|e| IoError::new(IoErrorKind::Other, e.to_string()))?;
108 +                 .map_err(|e| IoError::other(e.to_string()))?;
    |
```