### PR TITLE
chore(cliff): improve template

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -42,7 +42,11 @@ body = """
             {%- if contributor.pr_number %} in \
             [#{{ contributor.pr_number }}]({{ self::remote_url() }}/pull/{{ contributor.pr_number }}) \
             {%- endif %}
-{%- endfor %}\n\n
+{%- endfor %}\n
+
+{%- if github.contributors | filter(attribute="is_first_time", value=true) | length != 0 %}
+{% endif %}
+
 """
 # template for the changelog footer
 footer = """


### PR DESCRIPTION
There was no empty line between the list of new contributors and the next release. A previous attempt to fix this resulted in 2 empty lines when there were no new contributors.
There should also be an empty line before the footer. This change takes care of both of these cases.
