### PR TITLE
fix(lints): apply clippy suggestions

### DIFF
--- a/src/random.rs
+++ b/src/random.rs
@@ -46,17 +46,13 @@ impl RandomURLConfig {
 /// Type of the random URL.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "lowercase")]
+#[derive(Default)]
 pub enum RandomURLType {
     /// Generate a random pet name.
+    #[default]
     PetName,
     /// Generate a random alphanumeric string.
     Alphanumeric,
-}
-
-impl Default for RandomURLType {
-    fn default() -> Self {
-        Self::PetName
-    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
fix clippy warning, which is elevated to an error in CI:

```
error: this `impl` can be derived
  --> src/random.rs:56:1
   |
56 | / impl Default for RandomURLType {
57 | |     fn default() -> Self {
58 | |         Self::PetName
59 | |     }
60 | | }
   | |_^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.91.0/index.html#derivable_impls
   = note: `-D clippy::derivable-impls` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(clippy::derivable_impls)]`
help: replace the manual implementation with a derive attribute and mark the default variant
   |
49 + #[derive(Default)]
50 ~ pub enum RandomURLType {
51 |     /// Generate a random pet name.
52 ~     #[default]
53 ~     PetName,
   |

error: could not compile `rustypaste` (lib) due to 1 previous error
```
