### PR TITLE
feat(server): overriding filename when paste from remote URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ some text
     - [Paste file from remote URL](#paste-file-from-remote-url)
     - [Cleaning up expired files](#cleaning-up-expired-files)
     - [Delete file from server](#delete-file-from-server)
-    - [Override the filename when using `random_url`](#override-the-filename-when-using-random_url)
+    - [Override the filename when using `random_url` or pasting from remote URL](#override-the-filename-when-using-random_url-or-pasting-from-remote-url)
   - [Server](#server)
     - [Authentication](#authentication)
     - [List endpoint](#list-endpoint)
@@ -260,12 +260,14 @@ $ curl -H "Authorization: <auth_token>" -X DELETE "<server_address>/file.txt"
 
 > The `DELETE` endpoint will not be exposed and will return `404` error if `delete_tokens` are not set.
 
-#### Override the filename when using `random_url`
+#### Override the filename when using `random_url` or pasting from remote URL
 
-The generation of a random filename can be overridden by sending a header called `filename`:
+When using the `random_url` config option, or when pasting a file [from remote URL](#paste-file-from-remote-url), rustypaste automatically selects a filename.
+This can be overridden by sending a header called `filename`:
 
 ```sh
 curl -F "file=@x.txt" -H "filename: <file_name>" "<server_address>"
+curl -F "remote=https://example.com/file.png" -H "filename: <file_name>" "<server_address>"
 ```
 
 ### Server

--- a/README.md
+++ b/README.md
@@ -27,37 +27,37 @@ some text
 
 <!-- vim-markdown-toc GFM -->
 
-- [Features](#features)
-- [Installation](#installation)
-  - [From crates.io](#from-cratesio)
-  - [Arch Linux](#arch-linux)
-  - [Alpine Linux](#alpine-linux)
-  - [FreeBSD](#freebsd)
-  - [Binary releases](#binary-releases)
-  - [Build from source](#build-from-source)
-    - [Feature flags](#feature-flags)
-    - [Testing](#testing)
-      - [Unit tests](#unit-tests)
-      - [Test Fixtures](#test-fixtures)
-- [Usage](#usage)
-  - [CLI](#cli)
-    - [Expiration](#expiration)
-    - [One shot files](#one-shot-files)
-    - [One shot URLs](#one-shot-urls)
-    - [URL shortening](#url-shortening)
-    - [Paste file from remote URL](#paste-file-from-remote-url)
-    - [Cleaning up expired files](#cleaning-up-expired-files)
-    - [Delete file from server](#delete-file-from-server)
-    - [Override the filename when using `random_url` or pasting from remote URL](#override-the-filename-when-using-random_url-or-pasting-from-remote-url)
-  - [Server](#server)
-    - [Authentication](#authentication)
-    - [List endpoint](#list-endpoint)
-    - [HTML Form](#html-form)
-    - [Docker](#docker)
-    - [Nginx](#nginx)
-  - [Third Party Clients](#third-party-clients)
-  - [Contributing](#contributing)
-    - [License](#license)
+* [Features](#features)
+* [Installation](#installation)
+  * [From crates.io](#from-cratesio)
+  * [Arch Linux](#arch-linux)
+  * [Alpine Linux](#alpine-linux)
+  * [FreeBSD](#freebsd)
+  * [Binary releases](#binary-releases)
+  * [Build from source](#build-from-source)
+    * [Feature flags](#feature-flags)
+    * [Testing](#testing)
+      * [Unit tests](#unit-tests)
+      * [Test Fixtures](#test-fixtures)
+* [Usage](#usage)
+  * [CLI](#cli)
+    * [Expiration](#expiration)
+    * [One shot files](#one-shot-files)
+    * [One shot URLs](#one-shot-urls)
+    * [URL shortening](#url-shortening)
+    * [Paste file from remote URL](#paste-file-from-remote-url)
+    * [Cleaning up expired files](#cleaning-up-expired-files)
+    * [Delete file from server](#delete-file-from-server)
+    * [Override the filename](#override-the-filename)
+  * [Server](#server)
+    * [Authentication](#authentication)
+    * [List endpoint](#list-endpoint)
+    * [HTML Form](#html-form)
+    * [Docker](#docker)
+    * [Nginx](#nginx)
+  * [Third Party Clients](#third-party-clients)
+  * [Contributing](#contributing)
+    * [License](#license)
 
 <!-- vim-markdown-toc -->
 
@@ -260,9 +260,10 @@ $ curl -H "Authorization: <auth_token>" -X DELETE "<server_address>/file.txt"
 
 > The `DELETE` endpoint will not be exposed and will return `404` error if `delete_tokens` are not set.
 
-#### Override the filename when using `random_url` or pasting from remote URL
+#### Override the filename
 
 When using the `random_url` config option, or when pasting a file [from remote URL](#paste-file-from-remote-url), rustypaste automatically selects a filename.
+
 This can be overridden by sending a header called `filename`:
 
 ```sh

--- a/fixtures/test-remote-file-upload-override-filename/config.toml
+++ b/fixtures/test-remote-file-upload-override-filename/config.toml
@@ -1,0 +1,9 @@
+[server]
+address = "127.0.0.1:8000"
+max_content_length = "10MB"
+upload_path = "./upload"
+timeout = "60s"
+
+[paste]
+default_extension = "txt"
+duplicate_files = false

--- a/fixtures/test-remote-file-upload-override-filename/test.sh
+++ b/fixtures/test-remote-file-upload-override-filename/test.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+url="https://raw.githubusercontent.com/orhun/rustypaste/master/img/rustypaste_logo.png"
+
+setup() {
+  :;
+}
+
+run_test() {
+  file_url=$(curl -s -F "remote=$url" -H "filename:fn_from_header.txt" localhost:8000)
+  test "$file_url" = "http://localhost:8000/fn_from_header.txt"
+  curl -s "$file_url" -o uploaded_file > /dev/null
+  curl -s "$url" -o remote_file > /dev/null
+  test "$(sha256sum uploaded_file | awk '{print $1}')" = "$(sha256sum remote_file | awk '{print $1}')"
+}
+
+teardown() {
+  rm uploaded_file remote_file
+  rm -r upload
+}

--- a/src/paste.rs
+++ b/src/paste.rs
@@ -221,6 +221,7 @@ impl Paste {
     pub async fn store_remote_file(
         &mut self,
         expiry_date: Option<u128>,
+        header_filename: Option<String>,
         client: &Client,
         config: &RwLock<Config>,
     ) -> Result<String, Error> {
@@ -266,7 +267,7 @@ impl Paste {
                     .to_string());
             }
         }
-        self.store_file(file_name, expiry_date, None, &config)
+        self.store_file(file_name, expiry_date, header_filename, &config)
     }
 
     /// Writes an URL to a file in upload directory.
@@ -546,7 +547,7 @@ mod tests {
                 .finish(),
         );
         let file_name = paste
-            .store_remote_file(None, &client_data, &RwLock::new(config.clone()))
+            .store_remote_file(None, None, &client_data, &RwLock::new(config.clone()))
             .await?;
         let file_path = PasteType::RemoteFile
             .get_path(&config.server.upload_path)

--- a/src/server.rs
+++ b/src/server.rs
@@ -289,7 +289,7 @@ async fn upload(
                 }
                 PasteType::RemoteFile => {
                     paste
-                        .store_remote_file(expiry_date, &client, &config)
+                        .store_remote_file(expiry_date, header_filename, &client, &config)
                         .await?
                 }
                 PasteType::Url | PasteType::OneshotUrl => {

--- a/src/server.rs
+++ b/src/server.rs
@@ -1149,6 +1149,70 @@ mod tests {
     }
 
     #[actix_web::test]
+    async fn test_upload_remote_file_override_filename() -> Result<(), Error> {
+        let mut config = Config::default();
+        config.server.upload_path = env::current_dir()?;
+        config.server.max_content_length = Byte::from_u128(30000).unwrap_or_default();
+
+        let app = test::init_service(
+            App::new()
+                .app_data(Data::new(RwLock::new(config)))
+                .app_data(Data::new(
+                    ClientBuilder::new()
+                        .timeout(Duration::from_secs(30))
+                        .finish(),
+                ))
+                .configure(configure_routes),
+        )
+        .await;
+
+        let file_name = "fn_from_header.txt";
+        let response = test::call_service(
+            &app,
+            get_multipart_request(
+                "https://raw.githubusercontent.com/orhun/rustypaste/refs/heads/master/img/rp_test_3b5eeeee7a7326cd6141f54820e6356a0e9d1dd4021407cb1d5e9de9f034ed2f.png",
+                "remote",
+                file_name,
+            )
+            .insert_header((
+                header::HeaderName::from_static("filename"),
+                header::HeaderValue::from_static(file_name),
+            ))
+            .to_request(),
+        )
+        .await;
+        assert_eq!(StatusCode::OK, response.status());
+        assert_body(
+            response.into_body().boxed(),
+            &format!("http://localhost:8080/{file_name}\n"),
+        )
+        .await?;
+
+        let serve_request = TestRequest::get()
+            .uri(&format!("/{file_name}"))
+            .to_request();
+        let response = test::call_service(&app, serve_request).await;
+        assert_eq!(StatusCode::OK, response.status());
+
+        let body = response.into_body();
+        let body_bytes = actix_web::body::to_bytes(body).await?;
+        assert_eq!(
+            "3b5eeeee7a7326cd6141f54820e6356a0e9d1dd4021407cb1d5e9de9f034ed2f",
+            util::sha256_digest(&*body_bytes)?
+        );
+
+        fs::remove_file(file_name)?;
+
+        let serve_request = TestRequest::get()
+            .uri(&format!("/{file_name}"))
+            .to_request();
+        let response = test::call_service(&app, serve_request).await;
+        assert_eq!(StatusCode::NOT_FOUND, response.status());
+
+        Ok(())
+    }
+
+    #[actix_web::test]
     async fn test_upload_url() -> Result<(), Error> {
         let mut config = Config::default();
         config.server.upload_path = env::current_dir()?;


### PR DESCRIPTION
## Description

Add support for the `filename: abc.txt` header when uploading a paste from remote URL. So for example, this will now work:
```sh
curl -F "remote=https://example.com/file.png" -H "filename: foobar.png" "<server_address>"
```

## Motivation and Context

Previously, the `filename: ` header only worked for regular pastes, when the data is included in request's multipart/form-data. This addition makes the set of supported headers work more uniformly across other orthogonal features (remote vs. direct upload). Also, I personally needed this feature for reuploading files on discord's CDN, for an IRC bridge.

## How Has This Been Tested?

- Unit test for changes in `Paste::store_remote_file`
- Unit test for server `test_upload_remote_file_override_filename()`
- Test fixture `test_upload_remote_file_override_filename`
- Testing on my own instance deployment, with curl (a command like the example above)

## Changelog Entry

### Added
- Add support for overriding the filename, using the `filename: abc.txt` header, when uploading a paste from remote URL.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
