### PR TITLE
feat: add password-protected file uploads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -330,6 +330,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0952808a6c2afd1aa8947271f3a60f1a6763c7b912d210184c5149b5cf147247"
 
 [[package]]
+name = "argon2"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
+dependencies = [
+ "base64ct",
+ "blake2",
+ "cpufeatures",
+ "password-hash",
+]
+
+[[package]]
 name = "arraydeque"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -389,6 +401,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64ct"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e050f626429857a27ddccb31e0aca21356bfa709c04041aefddac081a8f068a"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -410,6 +428,15 @@ dependencies = [
  "radium",
  "tap",
  "wyz",
+]
+
+[[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest",
 ]
 
 [[package]]
@@ -696,6 +723,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -1560,6 +1588,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "944553dd59c802559559161f9816429058b869003836120e262e8caec061b7ae"
 
 [[package]]
+name = "password-hash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
+dependencies = [
+ "base64ct",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "path-clean"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1930,7 +1969,9 @@ dependencies = [
  "actix-rt",
  "actix-web",
  "actix-web-grants",
+ "argon2",
  "awc",
+ "base64",
  "byte-unit",
  "config",
  "dotenvy",
@@ -2181,6 +2222,12 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,9 +44,9 @@ dependencies = [
 
 [[package]]
 name = "actix-http"
-version = "3.12.1"
+version = "3.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93acb4a42f64936f9b8cae4a433b237599dd6eb6ed06124eb67132ef8cc90662"
+checksum = "48e2faa3e7418ed780cca54829d32782a4008a077230f67457caa063415e99c2"
 dependencies = [
  "actix-codec",
  "actix-rt",
@@ -61,7 +61,7 @@ dependencies = [
  "derive_more 2.1.1",
  "encoding_rs",
  "flate2",
- "foldhash 0.1.5",
+ "foldhash 0.2.0",
  "futures-core",
  "h2",
  "http 0.2.12",
@@ -195,7 +195,7 @@ dependencies = [
  "futures-core",
  "http 0.2.12",
  "http 1.4.1",
- "impl-more",
+ "impl-more 0.1.9",
  "openssl",
  "pin-project-lite",
  "rustls-pki-types",
@@ -219,9 +219,9 @@ dependencies = [
 
 [[package]]
 name = "actix-web"
-version = "4.13.0"
+version = "4.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff87453bc3b56e9b2b23c1cc0b1be8797184accf51d2abe0f8a33ec275d316bf"
+checksum = "df09e2d9239703dd64056359c920c7f3fba6535ec61a0059e0f44e095ffe02b4"
 dependencies = [
  "actix-codec",
  "actix-http",
@@ -239,10 +239,10 @@ dependencies = [
  "cookie",
  "derive_more 2.1.1",
  "encoding_rs",
- "foldhash 0.1.5",
+ "foldhash 0.2.0",
  "futures-core",
  "futures-util",
- "impl-more",
+ "impl-more 0.3.1",
  "itoa",
  "language-tags",
  "log",
@@ -511,9 +511,9 @@ checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "byte-unit"
-version = "5.2.0"
+version = "5.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c6d47a4e2961fb8721bcfc54feae6455f2f64e7054f9bc67e875f0e77f4c58d"
+checksum = "37bcaa4a0975bed4a760af3efe4368825098ce5f9d37a30c5a021d635dc63d8f"
 dependencies = [
  "rust_decimal",
  "schemars",
@@ -595,9 +595,9 @@ dependencies = [
 
 [[package]]
 name = "config"
-version = "0.15.23"
+version = "0.15.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f316c6237b2d38be61949ecd15268a4c6ca32570079394a2444d9ce2c72a72d8"
+checksum = "0b34d0237145f33580b89724f75d16950efd3e2c91b2d823917ecb69ec7f84f0"
 dependencies = [
  "pathdiff",
  "serde_core",
@@ -1305,6 +1305,12 @@ name = "impl-more"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8a5a9a0ff0086c7a148acb942baaabeadf9504d10400b5a05645853729b9cd2"
+
+[[package]]
+name = "impl-more"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35a84fd5aa25fae5c0f4a33d9cac2ca017fc622cbd089be2229993514990f870"
 
 [[package]]
 name = "indexmap"
@@ -2082,9 +2088,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.40"
+version = "0.23.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
 dependencies = [
  "once_cell",
  "ring",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -331,6 +331,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "argon2"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
+dependencies = [
+ "base64ct",
+ "blake2",
+ "cpufeatures 0.2.17",
+ "password-hash",
+]
+
+[[package]]
 name = "arraydeque"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -390,6 +402,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -411,6 +429,24 @@ dependencies = [
  "radium",
  "tap",
  "wyz",
+]
+
+[[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -553,7 +589,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.3.0",
  "rand_core 0.10.1",
 ]
 
@@ -604,6 +640,15 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
@@ -634,6 +679,16 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
 
 [[package]]
 name = "crypto-common"
@@ -726,13 +781,24 @@ dependencies = [
 
 [[package]]
 name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
+ "subtle",
+]
+
+[[package]]
+name = "digest"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.12.0",
  "const-oid",
- "crypto-common",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -922,6 +988,16 @@ dependencies = [
  "futures-task",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -1601,6 +1677,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "487f2ccd1e17ce8c1bfab3a65c89525af41cfad4c8659021a1e9a2aacd73b89b"
 
 [[package]]
+name = "password-hash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
+dependencies = [
+ "base64ct",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "path-clean"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2042,7 +2129,9 @@ dependencies = [
  "actix-rt",
  "actix-web",
  "actix-web-grants",
+ "argon2",
  "awc",
+ "base64",
  "byte-unit",
  "config",
  "dotenvy",
@@ -2205,8 +2294,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,7 +8,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f7b0a21988c1bf877cf4759ef5ddaac04c1c9fe808c9142ecb78ba97d97a28a"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "bytes",
  "futures-core",
  "futures-sink",
@@ -29,7 +29,7 @@ dependencies = [
  "actix-service",
  "actix-utils",
  "actix-web",
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "bytes",
  "derive_more",
  "futures-core",
@@ -54,14 +54,14 @@ dependencies = [
  "actix-tls",
  "actix-utils",
  "base64",
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "brotli",
  "bytes",
  "bytestring",
  "derive_more",
  "encoding_rs",
  "flate2",
- "foldhash 0.2.0",
+ "foldhash",
  "futures-core",
  "h2",
  "http 0.2.12",
@@ -89,7 +89,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e01ed3140b2f8d422c68afa1ed2e85d996ea619c988ac834d255db32138655cb"
 dependencies = [
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -127,7 +127,7 @@ dependencies = [
  "darling 0.23.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -194,7 +194,7 @@ dependencies = [
  "actix-utils",
  "futures-core",
  "http 0.2.12",
- "http 1.4.1",
+ "http 1.4.2",
  "impl-more 0.1.9",
  "openssl",
  "pin-project-lite",
@@ -239,7 +239,7 @@ dependencies = [
  "cookie",
  "derive_more",
  "encoding_rs",
- "foldhash 0.2.0",
+ "foldhash",
  "futures-core",
  "futures-util",
  "impl-more 0.3.1",
@@ -270,7 +270,7 @@ dependencies = [
  "actix-router",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -317,18 +317,12 @@ checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
 
 [[package]]
 name = "alloc-stdlib"
-version = "0.2.2"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
+checksum = "0e76a019e91224d279006ff972f1e984179a6e9feb050adba6ce8274aef23195"
 dependencies = [
  "alloc-no-stdlib",
 ]
-
-[[package]]
-name = "anyhow"
-version = "1.0.102"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "argon2"
@@ -350,9 +344,9 @@ checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
 
 [[package]]
 name = "arrayvec"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+checksum = "f02882884d3e1bc524fb12c79f107f6ad0e1cfd498c536ffb494301740995dfe"
 
 [[package]]
 name = "autocfg"
@@ -415,15 +409,15 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "bitvec"
-version = "1.0.1"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+checksum = "ddcec3d12c579d40898fe0a9a358a803c23e9c52ca3c425707f81c9436211837"
 dependencies = [
  "funty",
  "radium",
@@ -451,18 +445,18 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
 dependencies = [
  "hybrid-array",
 ]
 
 [[package]]
 name = "borsh"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfd1e3f8955a5d7de9fab72fc8373fade9fb8a703968cb200ae3dc6cf08e185a"
+checksum = "2f3f6da4992df95bbcd9af42a6c7dcb994498fc9048230405f3b36ff7cd3f145"
 dependencies = [
  "borsh-derive",
  "bytes",
@@ -471,22 +465,22 @@ dependencies = [
 
 [[package]]
 name = "borsh-derive"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfcfdc083699101d5a7965e49925975f2f55060f94f9a05e7187be95d530ca59"
+checksum = "3ae8fb4fb5740e4b2c4884ff95f5f32f5e8479db1e8fd8eb49ddbe09eb09bb7c"
 dependencies = [
  "once_cell",
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "brotli"
-version = "8.0.3"
+version = "8.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8119e4516436f5708bbc474a9d395bf12f1b5395e93a92a56e647ac3388c8610"
+checksum = "5cc91aac060a7a1e25823bdccbfb6af1875b88f17c6daac97894eed8207166b3"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -495,9 +489,9 @@ dependencies = [
 
 [[package]]
 name = "brotli-decompressor"
-version = "5.0.1"
+version = "5.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5962523e1b92ce1b5e793d9169b9943eece10d39f62550bc04bb605d75b94924"
+checksum = "3a32acac15fe1967bc3986b2a6347dffc965602354ea6f450ad07e8bfd253583"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -511,9 +505,9 @@ checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "byte-unit"
-version = "5.2.3"
+version = "5.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37bcaa4a0975bed4a760af3efe4368825098ce5f9d37a30c5a021d635dc63d8f"
+checksum = "4a813de7f2bbedb7dce265b64f1cf5908ebe4d56281ece8d847e98113788b9b0"
 dependencies = [
  "rust_decimal",
  "schemars",
@@ -545,9 +539,9 @@ dependencies = [
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 
 [[package]]
 name = "bytesize"
@@ -566,9 +560,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.63"
+version = "1.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
+checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -590,9 +584,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chacha20"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
@@ -601,9 +595,9 @@ dependencies = [
 
 [[package]]
 name = "config"
-version = "0.15.24"
+version = "0.15.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b34d0237145f33580b89724f75d16950efd3e2c91b2d823917ecb69ec7f84f0"
+checksum = "b85f248a4de22d204ceabc6299d89d2c70fbd7f09fea53c06c852369652d8139"
 dependencies = [
  "pathdiff",
  "serde_core",
@@ -730,7 +724,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -743,7 +737,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -754,7 +748,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -765,7 +759,7 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core 0.23.0",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -773,9 +767,6 @@ name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
-dependencies = [
- "powerfmt",
-]
 
 [[package]]
 name = "derive_more"
@@ -796,7 +787,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.117",
+ "syn 2.0.118",
  "unicode-xid",
 ]
 
@@ -817,7 +808,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
- "block-buffer 0.12.0",
+ "block-buffer 0.12.1",
  "const-oid",
  "crypto-common 0.2.2",
 ]
@@ -830,7 +821,7 @@ checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -919,12 +910,6 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
-
-[[package]]
-name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
@@ -982,7 +967,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1046,16 +1031,14 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
- "wasip2",
- "wasip3",
 ]
 
 [[package]]
@@ -1094,20 +1077,11 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
-dependencies = [
- "foldhash 0.1.5",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
- "foldhash 0.2.0",
+ "foldhash",
 ]
 
 [[package]]
@@ -1118,18 +1092,12 @@ checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hashlink"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea0b22561a9c04a7cb1a302c013e0259cd3b4bb619f145b32f72b8b4bcbed230"
+checksum = "824e001ac4f3012dd16a264bec811403a67ca9deb6c102fc5049b32c4574b35f"
 dependencies = [
  "hashbrown 0.16.1",
 ]
-
-[[package]]
-name = "heck"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hotwatch"
@@ -1155,9 +1123,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.1"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
 dependencies = [
  "bytes",
  "itoa",
@@ -1199,9 +1167,9 @@ dependencies = [
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
 dependencies = [
  "typenum",
 ]
@@ -1289,12 +1257,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1341,8 +1303,6 @@ checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
- "serde",
- "serde_core",
 ]
 
 [[package]]
@@ -1389,13 +1349,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.99"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
  "cfg-if",
  "futures-util",
- "once_cell",
  "wasm-bindgen",
 ]
 
@@ -1415,7 +1374,7 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "libc",
 ]
 
@@ -1445,7 +1404,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1453,12 +1412,6 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
@@ -1506,9 +1459,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.30"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "matchers"
@@ -1521,9 +1474,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.1"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "mime"
@@ -1581,7 +1534,7 @@ version = "6.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "crossbeam-channel",
  "filetime",
  "fsevent-sys",
@@ -1639,11 +1592,11 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "openssl"
-version = "0.10.80"
+version = "0.10.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
+checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -1659,14 +1612,14 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.116"
+version = "0.9.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
 dependencies = [
  "cc",
  "libc",
@@ -1696,12 +1649,6 @@ dependencies = [
  "smallvec",
  "windows-link",
 ]
-
-[[package]]
-name = "parse-size"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "487f2ccd1e17ce8c1bfab3a65c89525af41cfad4c8659021a1e9a2aacd73b89b"
 
 [[package]]
 name = "password-hash"
@@ -1734,9 +1681,9 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "petname"
-version = "3.0.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ce610bff48dd7b6a127e45631795fbb0b302b99a39bef7e6da3d297e8eb2b6b"
+checksum = "1201345ec6f6630308d0549e198c58aff61df8033afe094f072def1ebe43eafa"
 dependencies = [
  "petname-macros",
  "rand 0.10.1",
@@ -1744,13 +1691,13 @@ dependencies = [
 
 [[package]]
 name = "petname-macros"
-version = "3.0.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "324239bd00dcf61f1a0e301d4d8f6f8c080a755248fc3fdc817ee1fdbbc27b8b"
+checksum = "c9b4bcfb5a86125ae8f1342b95f8b64d050f0a4385c9533c5a17970b9e0479e7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1790,16 +1737,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prettyplease"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
-dependencies = [
- "proc-macro2",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "proc-macro-crate"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1826,7 +1763,7 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1851,9 +1788,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
@@ -1904,7 +1841,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "rand_core 0.10.1",
 ]
 
@@ -1958,7 +1895,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -1978,7 +1915,7 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2070,9 +2007,9 @@ dependencies = [
 
 [[package]]
 name = "rust_decimal"
-version = "1.42.0"
+version = "1.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c5108e3d4d903e21aac27f12ba5377b6b34f9f44b325e4894c7924169d06995"
+checksum = "be2a24f50780bc85f09cc6ac299bdf1424302742d77221106859c9d8b102126a"
 dependencies = [
  "arrayvec",
  "borsh",
@@ -2100,7 +2037,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -2258,7 +2195,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2370,9 +2307,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "socket2"
@@ -2425,9 +2362,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2442,7 +2379,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2458,7 +2395,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -2475,12 +2412,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.47"
+version = "0.3.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+checksum = "85c17d80feb7334b40c484e45ed1a5273dfd8bfda537c3be2e74a06a6686f327"
 dependencies = [
  "deranged",
- "itoa",
  "num-conv",
  "powerfmt",
  "serde_core",
@@ -2490,15 +2426,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.27"
+version = "0.2.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+checksum = "dcef1a61bdb119096e153208ec5cbec23944ce8bca13be5c7f60c634f7403935"
 dependencies = [
  "num-conv",
  "time-core",
@@ -2642,7 +2578,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2704,9 +2640,9 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.13.2"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-xid"
@@ -2752,9 +2688,9 @@ checksum = "8712317ff5e88daeaa227799067da4d2c6ec8741ad0aed09b3c2a56f571a71b9"
 
 [[package]]
 name = "uuid"
-version = "1.23.2"
+version = "1.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d258b83ceec21034727ecee8c382cfa6c3e133699b0742c64571814fb420c9f7"
+checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2802,27 +2738,18 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.3+wasi-0.2.9"
+version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
- "wit-bindgen 0.57.1",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen 0.51.0",
+ "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.122"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2833,9 +2760,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.122"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2843,58 +2770,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.122"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.122"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap",
- "wasm-encoder",
- "wasmparser",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags 2.11.1",
- "hashbrown 0.15.5",
- "indexmap",
- "semver",
 ]
 
 [[package]]
@@ -2903,14 +2796,14 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
 dependencies = [
- "webpki-roots 1.0.7",
+ "webpki-roots 1.0.8",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -3089,97 +2982,9 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap",
- "prettyplease",
- "syn 2.0.117",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags 2.11.1",
- "indexmap",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
 
 [[package]]
 name = "writeable"
@@ -3209,9 +3014,9 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -3226,28 +3031,28 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.50"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.50"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3267,15 +3072,15 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "synstructure",
 ]
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerotrie"
@@ -3307,7 +3112,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,8 @@ actix-files = "0.6.9"
 awc = { version = "3.8.1" }
 serde = "1.0.228"
 futures-util = "0.3.31"
+argon2 = "0.5"
+base64 = "0.22"
 petname = { version = "2.0.2", default-features = false, features = [
   "default-rng",
   "default-words",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,8 @@ actix-files = "0.6.10"
 awc = { version = "3.8.2" }
 serde = "1.0.228"
 futures-util = "0.3.32"
+argon2 = "0.5"
+base64 = "0.22"
 petname = { version = "3.0.0", default-features = false, features = [
   "default-rng",
   "default-words",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ actix-files = "0.6.10"
 awc = { version = "3.8.2" }
 serde = "1.0.228"
 futures-util = "0.3.32"
-argon2 = "0.5"
+argon2 = { version = "0.5", features = ["std"] } 
 base64 = "0.22"
 petname = { version = "3.0.0", default-features = false, features = [
   "default-rng",

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ some text
     - [Expiration](#expiration)
     - [One shot files](#one-shot-files)
     - [One shot URLs](#one-shot-urls)
+    - [Password-protected files](#password-protected-files)
     - [URL shortening](#url-shortening)
     - [Paste file from remote URL](#paste-file-from-remote-url)
     - [Cleaning up expired files](#cleaning-up-expired-files)
@@ -75,6 +76,9 @@ some text
     - auto-expiration of files (optional)
     - auto-deletion of expired files (optional)
   - supports one shot links/URLs (can only be viewed once)
+  - supports password-protected files
+    - auto-generated passwords
+    - Argon2id hashing
   - guesses MIME types
     - supports overriding and blacklisting
     - supports forcing to download via `?download=true`
@@ -222,6 +226,30 @@ $ curl -F "oneshot=@x.txt" "<server_address>"
 ```sh
 $ curl -F "oneshot_url=https://example.com" "<server_address>"
 ```
+
+#### Password-protected files
+
+Upload a file with auto-generated password:
+
+```sh
+$ curl -F "protected=@secret.txt" "<server_address>"
+https://paste.site.com/secret.txt
+Password: aBcD1234EfGh5678IjKl9012
+```
+
+Download with Bearer token:
+
+```sh
+$ curl -H "Authorization: Bearer aBcD1234EfGh5678IjKl9012" https://paste.site.com/secret.txt
+```
+
+Or with Basic Auth:
+
+```sh
+$ curl -u "user:aBcD1234EfGh5678IjKl9012" https://paste.site.com/secret.txt
+```
+
+**Note**: Protected files cannot be combined with other paste types (oneshot, URL). The password is permanently tied to the file and cannot be changed. If the password is lost, the file becomes inaccessible. Password files are deleted automatically when the main file is deleted or expires.
 
 #### URL shortening
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ some text
     * [Expiration](#expiration)
     * [One shot files](#one-shot-files)
     * [One shot URLs](#one-shot-urls)
+    * [Password-protected files](#password-protected-files)
     * [URL shortening](#url-shortening)
     * [Paste file from remote URL](#paste-file-from-remote-url)
     * [Cleaning up expired files](#cleaning-up-expired-files)
@@ -75,6 +76,9 @@ some text
     - auto-expiration of files (optional)
     - auto-deletion of expired files (optional)
   - supports one shot links/URLs (can only be viewed once)
+  - supports password-protected files
+    - auto-generated passwords
+    - Argon2id hashing
   - guesses MIME types
     - supports overriding and blacklisting
     - supports forcing to download via `?download=true`
@@ -221,6 +225,30 @@ $ curl -F "oneshot=@x.txt" "<server_address>"
 ```sh
 $ curl -F "oneshot_url=https://example.com" "<server_address>"
 ```
+
+#### Password-protected files
+
+Upload a file with auto-generated password:
+
+```sh
+$ curl -F "protected=@secret.txt" "<server_address>"
+https://paste.site.com/secret.txt
+Password: aBcD1234EfGh5678IjKl9012
+```
+
+Download with Bearer token:
+
+```sh
+$ curl -H "Authorization: Bearer aBcD1234EfGh5678IjKl9012" https://paste.site.com/secret.txt
+```
+
+Or with Basic Auth:
+
+```sh
+$ curl -u "user:aBcD1234EfGh5678IjKl9012" https://paste.site.com/secret.txt
+```
+
+**Note**: Protected files cannot be combined with other paste types (oneshot, URL). The password is permanently tied to the file and cannot be changed. If the password is lost, the file becomes inaccessible. Password files are deleted automatically when the main file is deleted or expires.
 
 #### URL shortening
 

--- a/examples/landing_page.html
+++ b/examples/landing_page.html
@@ -89,6 +89,12 @@ by default, pastes expire every hour.
       <input type="submit" value="share" />
     </form>
 
+    <h2>share password-protected file</h2>
+    <form action="/" method="post" enctype="multipart/form-data">
+      <input type="file" name="protected" />
+      <input type="submit" value="share" />
+    </form>
+
     <h2>share file with auth token</h2>
     <div id="shareForm">
       <input type="file" id="file" name="file" /><br>

--- a/fixtures/test-protected-file-delete/config.toml
+++ b/fixtures/test-protected-file-delete/config.toml
@@ -1,0 +1,9 @@
+[server]
+address = "127.0.0.1:8000"
+max_content_length = "10MB"
+upload_path = "./upload"
+delete_tokens = ["may_the_force_be_with_you"]
+
+[paste]
+default_extension = "txt"
+duplicate_files = true

--- a/fixtures/test-protected-file-delete/test.sh
+++ b/fixtures/test-protected-file-delete/test.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+content="protected delete test"
+
+setup() {
+  echo "$content" > file
+}
+
+run_test() {
+  # Upload protected file
+  response=$(curl -s -F "protected=@file" localhost:8000)
+
+  # Parse URL (first line) and password (second line after "Password: ")
+  file_url=$(echo "$response" | head -1)
+  password=$(echo "$response" | tail -1 | sed 's/Password: //')
+
+  # Verify file exists in protected directory
+  test "$content" = "$(cat upload/protected/file.txt)"
+
+  # Verify password file exists
+  test -f "upload/protected/file.txt.password"
+
+  # Delete the file
+  test "file deleted" = "$(curl -s -H "Authorization: may_the_force_be_with_you" -X DELETE "$file_url")"
+
+  # Verify both files are gone
+  test ! -f "upload/protected/file.txt"
+  test ! -f "upload/protected/file.txt.password"
+
+  # Second delete should fail
+  test "file is not found or expired :(" = "$(curl -s -H "Authorization: may_the_force_be_with_you" -X DELETE "$file_url")"
+}
+
+teardown() {
+  rm file
+  rm -r upload
+}

--- a/fixtures/test-protected-file-duplicate/config.toml
+++ b/fixtures/test-protected-file-duplicate/config.toml
@@ -1,0 +1,8 @@
+[server]
+address = "127.0.0.1:8000"
+max_content_length = "10MB"
+upload_path = "./upload"
+
+[paste]
+default_extension = "txt"
+duplicate_files = false

--- a/fixtures/test-protected-file-duplicate/test.sh
+++ b/fixtures/test-protected-file-duplicate/test.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+content="secret_protected_content"
+
+setup() {
+  echo "$content" > file
+}
+
+run_test() {
+  # Upload same file twice as protected
+  response1=$(curl -s -F "protected=@file" localhost:8000)
+  response2=$(curl -s -F "protected=@file" localhost:8000)
+
+  url1=$(echo "$response1" | head -1)
+  url2=$(echo "$response2" | head -1)
+  password1=$(echo "$response1" | tail -1 | sed 's/Password: //')
+  password2=$(echo "$response2" | tail -1 | sed 's/Password: //')
+
+  test "$url1" != "$url2"
+  test "$password1" != "$password2"
+}
+
+teardown() {
+  rm file
+  rm -r upload
+}

--- a/fixtures/test-protected-file-upload/config.toml
+++ b/fixtures/test-protected-file-upload/config.toml
@@ -1,0 +1,8 @@
+[server]
+address = "127.0.0.1:8000"
+max_content_length = "10MB"
+upload_path = "./upload"
+
+[paste]
+default_extension = "txt"
+duplicate_files = false

--- a/fixtures/test-protected-file-upload/test.sh
+++ b/fixtures/test-protected-file-upload/test.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+content="secret_protected_content"
+
+setup() {
+  echo "$content" > file
+}
+
+run_test() {
+  # Upload protected file
+  response=$(curl -s -F "protected=@file" localhost:8000)
+
+  # Parse URL (first line) and password (second line after "Password: ")
+  file_url=$(echo "$response" | head -1)
+  password=$(echo "$response" | tail -1 | sed 's/Password: //')
+
+  # Verify file exists in protected directory
+  test "$content" = "$(cat upload/protected/file.txt)"
+
+  # Verify password file exists
+  test -f "upload/protected/file.txt.password"
+
+  # Access without auth should fail (404)
+  result=$(curl -s -w '%{http_code}' -o /dev/null "$file_url")
+  test "$result" = "404"
+
+  # Access with wrong password should fail (404)
+  result=$(curl -s -w '%{http_code}' -o /dev/null -H "Authorization: Bearer wrongpassword" "$file_url")
+  test "$result" = "404"
+
+  # Access with correct Bearer auth should succeed
+  result=$(curl -s -H "Authorization: Bearer $password" "$file_url")
+  test "$content" = "$result"
+
+  # Access with correct Basic auth should succeed
+  basic_auth=$(echo -n "user:$password" | base64)
+  result=$(curl -s -H "Authorization: Basic $basic_auth" "$file_url")
+  test "$content" = "$result"
+}
+
+teardown() {
+  rm file
+  rm -r upload
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,9 @@ pub mod util;
 /// Custom middleware implementation.
 pub mod middleware;
 
+/// Password hashing and verification.
+pub mod password;
+
 // Use macros from tracing crate.
 #[macro_use]
 extern crate tracing;

--- a/src/password.rs
+++ b/src/password.rs
@@ -1,0 +1,174 @@
+//! Password generation, hashing, and verification for protected files.
+//!
+//! Protected files use Argon2id hashing with 19MB memory and 2 iterations.
+//! Passwords are stored in sidecar files (filename.txt.password) alongside
+//! the uploaded content.
+
+use argon2::{
+    password_hash::{rand_core::OsRng, PasswordHash, PasswordHasher, PasswordVerifier, SaltString},
+    Argon2, ParamsBuilder,
+};
+use rand::{distr::Alphanumeric, Rng};
+use std::fs;
+use std::io::{Error as IoError, ErrorKind as IoErrorKind, Result as IoResult};
+use std::path::{Path, PathBuf};
+
+/// Generate random alphanumeric password (24 chars = ~143 bits entropy)
+pub fn generate_password() -> String {
+    rand::rng()
+        .sample_iter(&Alphanumeric)
+        .take(24)
+        .map(char::from)
+        .collect()
+}
+
+/// Hash password using Argon2id (19MB memory, 2 iterations)
+pub fn hash_password(password: &str) -> Result<String, IoError> {
+    let salt = SaltString::generate(&mut OsRng);
+    let params = ParamsBuilder::new()
+        .m_cost(19456) // 19MB
+        .t_cost(2)
+        .p_cost(1)
+        .build()
+        .map_err(|e| IoError::other(format!("argon2 params: {}", e)))?;
+
+    let argon2 = Argon2::new(argon2::Algorithm::Argon2id, argon2::Version::V0x13, params);
+
+    argon2
+        .hash_password(password.as_bytes(), &salt)
+        .map(|hash| hash.to_string())
+        .map_err(|e| IoError::other(format!("hash failed: {}", e)))
+}
+
+/// Verify password against hash (constant-time)
+pub fn verify_password(password: &str, hash: &str) -> bool {
+    PasswordHash::new(hash)
+        .ok()
+        .and_then(|parsed| {
+            Argon2::default()
+                .verify_password(password.as_bytes(), &parsed)
+                .ok()
+        })
+        .is_some()
+}
+
+/// Get password file path for a given file
+pub fn get_password_file_path(file_path: &Path) -> IoResult<PathBuf> {
+    let current_name = file_path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .ok_or_else(|| {
+            IoError::new(
+                IoErrorKind::InvalidInput,
+                "file path contains invalid characters",
+            )
+        })?;
+
+    let mut path = file_path.to_path_buf();
+    path.set_file_name(format!("{}.password", current_name));
+    Ok(path)
+}
+
+/// Store password hash in sidecar file (file.txt -> file.txt.password)
+pub fn store_password_hash(file_path: &Path, password: &str) -> IoResult<()> {
+    let hash = hash_password(password)?;
+    let password_path = get_password_file_path(file_path)?;
+    fs::write(password_path, hash)
+}
+
+/// Check if file has password protection
+pub fn has_password(file_path: &Path) -> bool {
+    get_password_file_path(file_path)
+        .map(|p| p.exists())
+        .unwrap_or(false)
+}
+
+/// Verify password for a file
+pub fn verify_file_password(file_path: &Path, password: &str) -> IoResult<bool> {
+    let password_path = get_password_file_path(file_path)?;
+    let hash = fs::read_to_string(password_path)?;
+    Ok(verify_password(password, hash.trim()))
+}
+
+/// Delete password file
+pub fn delete_password_file(file_path: &Path) -> IoResult<()> {
+    let password_path = get_password_file_path(file_path)?;
+    if password_path.exists() {
+        fs::remove_file(password_path)?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::env;
+
+    #[test]
+    fn test_password_hashing() {
+        let password = "test_password_123";
+        let hash = hash_password(password).unwrap();
+        assert!(verify_password(password, &hash));
+        assert!(!verify_password("wrong", &hash));
+    }
+
+    #[test]
+    fn test_password_file_path() -> IoResult<()> {
+        let test_path = PathBuf::from("/tmp/test_file.txt");
+        let password_path = get_password_file_path(&test_path)?;
+
+        assert_eq!(PathBuf::from("/tmp/test_file.txt.password"), password_path);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_password_file_path_invalid_utf8() {
+        // This tests the error handling for invalid paths
+        // On Unix, we can create paths with invalid UTF-8
+        #[cfg(unix)]
+        {
+            use std::ffi::OsStr;
+            use std::os::unix::ffi::OsStrExt;
+
+            // Create a path with invalid UTF-8 bytes
+            let invalid_bytes = &[0x66, 0x6f, 0x6f, 0x80, 0x81];
+            let invalid_os_str = OsStr::from_bytes(invalid_bytes);
+            let invalid_path = PathBuf::from(invalid_os_str);
+
+            // Should return error, not panic
+            assert!(get_password_file_path(&invalid_path).is_err());
+        }
+    }
+
+    #[test]
+    fn test_store_and_verify_password() -> IoResult<()> {
+        let current_dir = env::current_dir()?;
+        let test_file = current_dir.join("test_password_roundtrip.txt");
+
+        // Create test file
+        fs::write(&test_file, "test content")?;
+
+        let password = "my_test_password";
+
+        // Store password hash
+        store_password_hash(&test_file, password)?;
+
+        // Verify password file exists
+        assert!(has_password(&test_file));
+
+        // Verify correct password
+        assert!(verify_file_password(&test_file, password)?);
+
+        // Verify wrong password fails
+        assert!(!verify_file_password(&test_file, "wrong_password")?);
+
+        // Cleanup
+        delete_password_file(&test_file)?;
+        fs::remove_file(&test_file)?;
+
+        assert!(!has_password(&test_file));
+
+        Ok(())
+    }
+}

--- a/src/password.rs
+++ b/src/password.rs
@@ -26,14 +26,14 @@ pub fn hash_password(password: &str) -> Result<String, IoError> {
         .t_cost(2)
         .p_cost(1)
         .build()
-        .map_err(|e| IoError::other(format!("argon2 params: {}", e)))?;
+        .map_err(|e| IoError::other(format!("argon2 params: {e}")))?;
 
     let argon2 = Argon2::new(argon2::Algorithm::Argon2id, argon2::Version::V0x13, params);
 
     argon2
         .hash_password(password.as_bytes(), &salt)
         .map(|hash| hash.to_string())
-        .map_err(|e| IoError::other(format!("hash failed: {}", e)))
+        .map_err(|e| IoError::other(format!("hash failed: {e}")))
 }
 
 /// Verify password against hash (constant-time)
@@ -61,7 +61,7 @@ pub fn get_password_file_path(file_path: &Path) -> IoResult<PathBuf> {
         })?;
 
     let mut path = file_path.to_path_buf();
-    path.set_file_name(format!("{}.password", current_name));
+    path.set_file_name(format!("{current_name}.password"));
     Ok(path)
 }
 
@@ -103,7 +103,7 @@ mod tests {
     #[test]
     fn test_password_hashing() {
         let password = "test_password_123";
-        let hash = hash_password(password).unwrap();
+        let hash = hash_password(password).expect("hashing should succeed in test");
         assert!(verify_password(password, &hash));
         assert!(!verify_password("wrong", &hash));
     }

--- a/src/password.rs
+++ b/src/password.rs
@@ -1,0 +1,170 @@
+//! Password generation, hashing, and verification for protected files.
+//!
+//! Protected files use Argon2id hashing with 19MB memory and 2 iterations.
+//! Passwords are stored in sidecar files (filename.txt.password) alongside
+//! the uploaded content.
+
+use argon2::{
+    password_hash::{rand_core::OsRng, PasswordHash, PasswordHasher, PasswordVerifier, SaltString},
+    Argon2, ParamsBuilder,
+};
+use rand::distr::{Alphanumeric, SampleString};
+use std::fs;
+use std::io::{Error as IoError, ErrorKind as IoErrorKind, Result as IoResult};
+use std::path::{Path, PathBuf};
+
+/// Generate random alphanumeric password (24 chars = ~143 bits entropy)
+pub fn generate_password() -> String {
+    Alphanumeric.sample_string(&mut rand::rng(), 24)
+}
+
+/// Hash password using Argon2id (19MB memory, 2 iterations)
+pub fn hash_password(password: &str) -> Result<String, IoError> {
+    let salt = SaltString::generate(&mut OsRng);
+    let params = ParamsBuilder::new()
+        .m_cost(19456) // 19MB
+        .t_cost(2)
+        .p_cost(1)
+        .build()
+        .map_err(|e| IoError::other(format!("argon2 params: {}", e)))?;
+
+    let argon2 = Argon2::new(argon2::Algorithm::Argon2id, argon2::Version::V0x13, params);
+
+    argon2
+        .hash_password(password.as_bytes(), &salt)
+        .map(|hash| hash.to_string())
+        .map_err(|e| IoError::other(format!("hash failed: {}", e)))
+}
+
+/// Verify password against hash (constant-time)
+pub fn verify_password(password: &str, hash: &str) -> bool {
+    PasswordHash::new(hash)
+        .ok()
+        .and_then(|parsed| {
+            Argon2::default()
+                .verify_password(password.as_bytes(), &parsed)
+                .ok()
+        })
+        .is_some()
+}
+
+/// Get password file path for a given file
+pub fn get_password_file_path(file_path: &Path) -> IoResult<PathBuf> {
+    let current_name = file_path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .ok_or_else(|| {
+            IoError::new(
+                IoErrorKind::InvalidInput,
+                "file path contains invalid characters",
+            )
+        })?;
+
+    let mut path = file_path.to_path_buf();
+    path.set_file_name(format!("{}.password", current_name));
+    Ok(path)
+}
+
+/// Store password hash in sidecar file (file.txt -> file.txt.password)
+pub fn store_password_hash(file_path: &Path, password: &str) -> IoResult<()> {
+    let hash = hash_password(password)?;
+    let password_path = get_password_file_path(file_path)?;
+    fs::write(password_path, hash)
+}
+
+/// Check if file has password protection
+pub fn has_password(file_path: &Path) -> bool {
+    get_password_file_path(file_path)
+        .map(|p| p.exists())
+        .unwrap_or(false)
+}
+
+/// Verify password for a file
+pub fn verify_file_password(file_path: &Path, password: &str) -> IoResult<bool> {
+    let password_path = get_password_file_path(file_path)?;
+    let hash = fs::read_to_string(password_path)?;
+    Ok(verify_password(password, hash.trim()))
+}
+
+/// Delete password file
+pub fn delete_password_file(file_path: &Path) -> IoResult<()> {
+    let password_path = get_password_file_path(file_path)?;
+    if password_path.exists() {
+        fs::remove_file(password_path)?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::env;
+
+    #[test]
+    fn test_password_hashing() {
+        let password = "test_password_123";
+        let hash = hash_password(password).unwrap();
+        assert!(verify_password(password, &hash));
+        assert!(!verify_password("wrong", &hash));
+    }
+
+    #[test]
+    fn test_password_file_path() -> IoResult<()> {
+        let test_path = PathBuf::from("/tmp/test_file.txt");
+        let password_path = get_password_file_path(&test_path)?;
+
+        assert_eq!(PathBuf::from("/tmp/test_file.txt.password"), password_path);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_password_file_path_invalid_utf8() {
+        // This tests the error handling for invalid paths
+        // On Unix, we can create paths with invalid UTF-8
+        #[cfg(unix)]
+        {
+            use std::ffi::OsStr;
+            use std::os::unix::ffi::OsStrExt;
+
+            // Create a path with invalid UTF-8 bytes
+            let invalid_bytes = &[0x66, 0x6f, 0x6f, 0x80, 0x81];
+            let invalid_os_str = OsStr::from_bytes(invalid_bytes);
+            let invalid_path = PathBuf::from(invalid_os_str);
+
+            // Should return error, not panic
+            assert!(get_password_file_path(&invalid_path).is_err());
+        }
+    }
+
+    #[test]
+    fn test_store_and_verify_password() -> IoResult<()> {
+        let current_dir = env::current_dir()?;
+        let test_file = current_dir.join("test_password_roundtrip.txt");
+
+        // Create test file
+        fs::write(&test_file, "test content")?;
+
+        let password = "my_test_password";
+
+        // Store password hash
+        store_password_hash(&test_file, password)?;
+
+        // Verify password file exists
+        assert!(has_password(&test_file));
+
+        // Verify correct password
+        assert!(verify_file_password(&test_file, password)?);
+
+        // Verify wrong password fails
+        assert!(!verify_file_password(&test_file, "wrong_password")?);
+
+        // Cleanup
+        delete_password_file(&test_file)?;
+        fs::remove_file(&test_file)?;
+
+        assert!(!has_password(&test_file));
+
+        Ok(())
+    }
+}

--- a/src/paste.rs
+++ b/src/paste.rs
@@ -28,6 +28,8 @@ pub enum PasteType {
     Url,
     /// A oneshot url.
     OneshotUrl,
+    /// A password-protected file.
+    ProtectedFile,
 }
 
 impl<'a> TryFrom<&'a ContentDisposition> for PasteType {
@@ -43,6 +45,8 @@ impl<'a> TryFrom<&'a ContentDisposition> for PasteType {
             Ok(Self::OneshotUrl)
         } else if content_disposition.has_form_field("url") {
             Ok(Self::Url)
+        } else if content_disposition.has_form_field("protected") {
+            Ok(Self::ProtectedFile)
         } else {
             Err(())
         }
@@ -57,6 +61,7 @@ impl PasteType {
             Self::Oneshot => String::from("oneshot"),
             Self::Url => String::from("url"),
             Self::OneshotUrl => String::from("oneshot_url"),
+            Self::ProtectedFile => String::from("protected"),
         }
     }
 
@@ -74,6 +79,11 @@ impl PasteType {
     pub fn is_oneshot(&self) -> bool {
         self == &Self::Oneshot
     }
+
+    /// Returns `true` if the variant is [`ProtectedFile`](Self::ProtectedFile).
+    pub fn is_protected(&self) -> bool {
+        self == &Self::ProtectedFile
+    }
 }
 
 /// Representation of a single paste.
@@ -83,6 +93,18 @@ pub struct Paste {
     pub data: Vec<u8>,
     /// Type of the data.
     pub type_: PasteType,
+}
+
+/// Result of uploading a file.
+#[derive(Debug)]
+pub struct UploadResult {
+    /// The filename of the uploaded file.
+    pub filename: String,
+    /// The password for protected files, if applicable.
+    ///
+    /// This is `Some` only for `PasteType::ProtectedFile`.
+    /// All other paste types return `None`.
+    pub password: Option<String>,
 }
 
 impl Paste {
@@ -101,7 +123,7 @@ impl Paste {
         expiry_date: Option<u128>,
         header_filename: Option<String>,
         config: &Config,
-    ) -> Result<String, Error> {
+    ) -> Result<UploadResult, Error> {
         let file_type = infer::get(&self.data);
         if let Some(file_type) = file_type {
             for mime_type in &config.paste.mime_blacklist {
@@ -192,9 +214,24 @@ impl Paste {
         if let Some(timestamp) = expiry_date {
             path.set_file_name(format!("{file_name}.{timestamp}"));
         }
+
+        // Generate and store password BEFORE creating content (prevents unprotected window)
+        let password = if self.type_.is_protected() {
+            let pwd = crate::password::generate_password();
+            crate::password::store_password_hash(&path, &pwd)
+                .map_err(|e| error::ErrorInternalServerError(format!("password storage: {}", e)))?;
+            Some(pwd)
+        } else {
+            None
+        };
+
         let mut buffer = File::create(&path)?;
         buffer.write_all(&self.data)?;
-        Ok(file_name)
+
+        Ok(UploadResult {
+            filename: file_name,
+            password,
+        })
     }
 
     /// Downloads a file from URL and stores it with [`store_file`].
@@ -211,7 +248,7 @@ impl Paste {
         header_filename: Option<String>,
         client: &Client,
         config: &RwLock<Config>,
-    ) -> Result<String, Error> {
+    ) -> Result<UploadResult, Error> {
         let data = str::from_utf8(&self.data).map_err(error::ErrorBadRequest)?;
         let url = Url::parse(data).map_err(error::ErrorBadRequest)?;
         let url_clone = url.clone();
@@ -255,12 +292,15 @@ impl Paste {
             if let Some(file) =
                 Directory::try_from(config.server.upload_path.as_path())?.get_file(bytes_checksum)
             {
-                return Ok(file
-                    .path
-                    .file_name()
-                    .map(|v| v.to_string_lossy())
-                    .unwrap_or_default()
-                    .to_string());
+                return Ok(UploadResult {
+                    filename: file
+                        .path
+                        .file_name()
+                        .map(|v| v.to_string_lossy())
+                        .unwrap_or_default()
+                        .to_string(),
+                    password: None,
+                });
             }
         }
         self.store_file(file_name, expiry_date, header_filename, &config)
@@ -278,7 +318,7 @@ impl Paste {
         expiry_date: Option<u128>,
         header_filename: Option<String>,
         config: &Config,
-    ) -> IoResult<String> {
+    ) -> IoResult<UploadResult> {
         let data = str::from_utf8(&self.data).map_err(|e| IoError::other(e.to_string()))?;
         let url = Url::parse(data).map_err(|e| IoError::other(e.to_string()))?;
         let mut file_name = self.type_.get_dir();
@@ -296,7 +336,10 @@ impl Paste {
             path.set_file_name(format!("{file_name}.{timestamp}"));
         }
         fs::write(&path, url.to_string())?;
-        Ok(file_name)
+        Ok(UploadResult {
+            filename: file_name,
+            password: None,
+        })
     }
 }
 
@@ -328,15 +371,15 @@ mod tests {
             data: vec![65, 66, 67],
             type_: PasteType::File,
         };
-        let file_name = paste.store_file("test.txt", None, None, &config)?;
-        assert_eq!("ABC", fs::read_to_string(&file_name)?);
+        let result = paste.store_file("test.txt", None, None, &config)?;
+        assert_eq!("ABC", fs::read_to_string(&result.filename)?);
         assert_eq!(
             Some("txt"),
-            PathBuf::from(&file_name)
+            PathBuf::from(&result.filename)
                 .extension()
                 .and_then(|v| v.to_str())
         );
-        fs::remove_file(file_name)?;
+        fs::remove_file(result.filename)?;
 
         config.paste.random_url = Some(RandomURLConfig {
             length: Some(4),
@@ -348,11 +391,11 @@ mod tests {
             data: vec![116, 101, 115, 115, 117, 115],
             type_: PasteType::File,
         };
-        let file_name = paste.store_file("foo.tar.gz", None, None, &config)?;
-        assert_eq!("tessus", fs::read_to_string(&file_name)?);
-        assert!(file_name.ends_with(".tar.gz"));
-        assert!(file_name.starts_with("foo."));
-        fs::remove_file(file_name)?;
+        let result = paste.store_file("foo.tar.gz", None, None, &config)?;
+        assert_eq!("tessus", fs::read_to_string(&result.filename)?);
+        assert!(result.filename.ends_with(".tar.gz"));
+        assert!(result.filename.starts_with("foo."));
+        fs::remove_file(result.filename)?;
 
         config.paste.random_url = Some(RandomURLConfig {
             length: Some(4),
@@ -364,11 +407,11 @@ mod tests {
             data: vec![116, 101, 115, 115, 117, 115],
             type_: PasteType::File,
         };
-        let file_name = paste.store_file(".foo.tar.gz", None, None, &config)?;
-        assert_eq!("tessus", fs::read_to_string(&file_name)?);
-        assert!(file_name.ends_with(".tar.gz"));
-        assert!(file_name.starts_with(".foo."));
-        fs::remove_file(file_name)?;
+        let result = paste.store_file(".foo.tar.gz", None, None, &config)?;
+        assert_eq!("tessus", fs::read_to_string(&result.filename)?);
+        assert!(result.filename.ends_with(".tar.gz"));
+        assert!(result.filename.starts_with(".foo."));
+        fs::remove_file(result.filename)?;
 
         config.paste.random_url = Some(RandomURLConfig {
             length: Some(4),
@@ -380,10 +423,10 @@ mod tests {
             data: vec![116, 101, 115, 115, 117, 115],
             type_: PasteType::File,
         };
-        let file_name = paste.store_file("foo.tar.gz", None, None, &config)?;
-        assert_eq!("tessus", fs::read_to_string(&file_name)?);
-        assert!(file_name.ends_with(".tar.gz"));
-        fs::remove_file(file_name)?;
+        let result = paste.store_file("foo.tar.gz", None, None, &config)?;
+        assert_eq!("tessus", fs::read_to_string(&result.filename)?);
+        assert!(result.filename.ends_with(".tar.gz"));
+        fs::remove_file(result.filename)?;
 
         config.paste.default_extension = String::from("txt");
         config.paste.random_url = None;
@@ -391,10 +434,10 @@ mod tests {
             data: vec![120, 121, 122],
             type_: PasteType::File,
         };
-        let file_name = paste.store_file(".foo", None, None, &config)?;
-        assert_eq!("xyz", fs::read_to_string(&file_name)?);
-        assert_eq!(".foo.txt", file_name);
-        fs::remove_file(file_name)?;
+        let result = paste.store_file(".foo", None, None, &config)?;
+        assert_eq!("xyz", fs::read_to_string(&result.filename)?);
+        assert_eq!(".foo.txt", result.filename);
+        fs::remove_file(result.filename)?;
 
         config.paste.default_extension = String::from("bin");
         config.paste.random_url = Some(RandomURLConfig {
@@ -406,15 +449,15 @@ mod tests {
             data: vec![120, 121, 122],
             type_: PasteType::File,
         };
-        let file_name = paste.store_file("random", None, None, &config)?;
-        assert_eq!("xyz", fs::read_to_string(&file_name)?);
+        let result = paste.store_file("random", None, None, &config)?;
+        assert_eq!("xyz", fs::read_to_string(&result.filename)?);
         assert_eq!(
             Some("bin"),
-            PathBuf::from(&file_name)
+            PathBuf::from(&result.filename)
                 .extension()
                 .and_then(|v| v.to_str())
         );
-        fs::remove_file(file_name)?;
+        fs::remove_file(result.filename)?;
 
         config.paste.random_url = Some(RandomURLConfig {
             length: Some(4),
@@ -426,15 +469,15 @@ mod tests {
             data: vec![116, 101, 115, 115, 117, 115],
             type_: PasteType::File,
         };
-        let file_name = paste.store_file(
+        let result = paste.store_file(
             "filename.txt",
             None,
             Some("fn_from_header.txt".to_string()),
             &config,
         )?;
-        assert_eq!("tessus", fs::read_to_string(&file_name)?);
-        assert_eq!("fn_from_header.txt", file_name);
-        fs::remove_file(file_name)?;
+        assert_eq!("tessus", fs::read_to_string(&result.filename)?);
+        assert_eq!("fn_from_header.txt", result.filename);
+        fs::remove_file(result.filename)?;
 
         config.paste.random_url = Some(RandomURLConfig {
             length: Some(4),
@@ -446,15 +489,15 @@ mod tests {
             data: vec![116, 101, 115, 115, 117, 115],
             type_: PasteType::File,
         };
-        let file_name = paste.store_file(
+        let result = paste.store_file(
             "filename.txt",
             None,
             Some("fn_from_header".to_string()),
             &config,
         )?;
-        assert_eq!("tessus", fs::read_to_string(&file_name)?);
-        assert_eq!("fn_from_header", file_name);
-        fs::remove_file(file_name)?;
+        assert_eq!("tessus", fs::read_to_string(&result.filename)?);
+        assert_eq!("fn_from_header", result.filename);
+        fs::remove_file(result.filename)?;
 
         config.paste.random_url = Some(RandomURLConfig {
             length: Some(8),
@@ -466,10 +509,10 @@ mod tests {
             data: vec![116, 101, 115, 115, 117, 115],
             type_: PasteType::File,
         };
-        let file_name = paste.store_file("filename.txt", None, None, &config)?;
-        assert_eq!("tessus", fs::read_to_string(&file_name)?);
-        assert_eq!(8, file_name.len());
-        fs::remove_file(file_name)?;
+        let result = paste.store_file("filename.txt", None, None, &config)?;
+        assert_eq!("tessus", fs::read_to_string(&result.filename)?);
+        assert_eq!(8, result.filename.len());
+        fs::remove_file(result.filename)?;
 
         for paste_type in &[PasteType::Url, PasteType::Oneshot] {
             fs::create_dir_all(
@@ -485,11 +528,11 @@ mod tests {
             type_: PasteType::Oneshot,
         };
         let expiry_date = util::get_system_time()?.as_millis() + 100;
-        let file_name = paste.store_file("test.file", Some(expiry_date), None, &config)?;
+        let result = paste.store_file("test.file", Some(expiry_date), None, &config)?;
         let file_path = PasteType::Oneshot
             .get_path(&config.server.upload_path)
             .expect("Bad upload path")
-            .join(format!("{file_name}.{expiry_date}"));
+            .join(format!("{}.{expiry_date}", result.filename));
         assert_eq!("test", fs::read_to_string(&file_path)?);
         fs::remove_file(file_path)?;
 
@@ -502,11 +545,11 @@ mod tests {
             data: url.as_bytes().to_vec(),
             type_: PasteType::Url,
         };
-        let file_name = paste.store_url(None, None, &config)?;
+        let result = paste.store_url(None, None, &config)?;
         let file_path = PasteType::Url
             .get_path(&config.server.upload_path)
             .expect("Bad upload path")
-            .join(&file_name);
+            .join(&result.filename);
         assert_eq!(url, fs::read_to_string(&file_path)?);
         fs::remove_file(file_path)?;
 
@@ -522,12 +565,12 @@ mod tests {
             data: url.as_bytes().to_vec(),
             type_: PasteType::Url,
         };
-        let prepared_result = paste.store_url(None, Some("prepared-name".to_string()), &config)?;
+        let result = paste.store_url(None, Some("prepared-name".to_string()), &config)?;
         let file_path = PasteType::Url
             .get_path(&config.server.upload_path)
             .expect("Bad upload path")
-            .join(&prepared_result);
-        assert_eq!(prepared_result, "prepared-name");
+            .join(&result.filename);
+        assert_eq!(result.filename, "prepared-name");
         assert_eq!(url, fs::read_to_string(&file_path)?);
         fs::remove_file(file_path)?;
 
@@ -542,13 +585,13 @@ mod tests {
                 .timeout(Duration::from_secs(30))
                 .finish(),
         );
-        let file_name = paste
+        let result = paste
             .store_remote_file(None, None, &client_data, &RwLock::new(config.clone()))
             .await?;
         let file_path = PasteType::RemoteFile
             .get_path(&config.server.upload_path)
             .expect("Bad upload path")
-            .join(file_name);
+            .join(result.filename);
         assert_eq!(
             "3b5eeeee7a7326cd6141f54820e6356a0e9d1dd4021407cb1d5e9de9f034ed2f",
             util::sha256_digest(&*paste.data)?
@@ -566,7 +609,7 @@ mod tests {
                 .timeout(Duration::from_secs(30))
                 .finish(),
         );
-        let file_name = paste
+        let result = paste
             .store_remote_file(
                 None,
                 Some("fn_from_header.txt".to_string()),
@@ -574,11 +617,11 @@ mod tests {
                 &RwLock::new(config.clone()),
             )
             .await?;
-        assert_eq!("fn_from_header.txt", file_name);
+        assert_eq!("fn_from_header.txt", result.filename);
         let file_path = PasteType::RemoteFile
             .get_path(&config.server.upload_path)
             .expect("Bad upload path")
-            .join(file_name);
+            .join(result.filename);
         assert_eq!(
             "3b5eeeee7a7326cd6141f54820e6356a0e9d1dd4021407cb1d5e9de9f034ed2f",
             util::sha256_digest(&*paste.data)?

--- a/src/paste.rs
+++ b/src/paste.rs
@@ -219,7 +219,7 @@ impl Paste {
         let password = if self.type_.is_protected() {
             let pwd = crate::password::generate_password();
             crate::password::store_password_hash(&path, &pwd)
-                .map_err(|e| error::ErrorInternalServerError(format!("password storage: {}", e)))?;
+                .map_err(|e| error::ErrorInternalServerError(format!("password storage: {e}")))?;
             Some(pwd)
         } else {
             None

--- a/src/server.rs
+++ b/src/server.rs
@@ -14,6 +14,7 @@ use actix_web_grants::GrantsMiddleware;
 use awc::error::HeaderValue;
 use awc::http::header::{CONTENT_SECURITY_POLICY, X_CONTENT_TYPE_OPTIONS};
 use awc::Client;
+use base64::Engine;
 use byte_unit::{Byte, UnitType};
 use futures_util::stream::StreamExt;
 use mime::TEXT_PLAIN_UTF_8;
@@ -25,6 +26,23 @@ use std::path::PathBuf;
 use std::sync::RwLock;
 use std::time::{Duration, UNIX_EPOCH};
 use uts2ts;
+
+/// Extract password from Authorization header.
+///
+/// Supports Basic Auth (`Basic base64(user:pass)`) and Bearer tokens (`Bearer <token>`).
+fn extract_password_from_auth(auth_header: &str) -> Option<String> {
+    if let Some(basic) = auth_header.strip_prefix("Basic ") {
+        let bytes = base64::engine::general_purpose::STANDARD
+            .decode(basic)
+            .ok()?;
+        let creds = String::from_utf8(bytes).ok()?;
+        creds.split_once(':').map(|(_, p)| p.to_owned())
+    } else {
+        auth_header
+            .strip_prefix("Bearer ")
+            .map(|bearer| bearer.to_owned())
+    }
+}
 
 /// Shows the landing page.
 #[get("/")]
@@ -94,7 +112,12 @@ async fn serve(
     let mut path = util::glob_match_file(safe_path_join(&config.server.upload_path, &*file)?)?;
     let mut paste_type = PasteType::File;
     if !path.exists() || path.is_dir() {
-        for type_ in &[PasteType::Url, PasteType::Oneshot, PasteType::OneshotUrl] {
+        for type_ in &[
+            PasteType::Url,
+            PasteType::Oneshot,
+            PasteType::OneshotUrl,
+            PasteType::ProtectedFile,
+        ] {
             let alt_path = safe_path_join(type_.get_path(&config.server.upload_path)?, &*file)?;
             let alt_path = util::glob_match_file(alt_path)?;
             if alt_path.exists()
@@ -109,8 +132,28 @@ async fn serve(
     if !path.is_file() || !path.exists() {
         return Err(error::ErrorNotFound("file is not found or expired :(\n"));
     }
+
+    // Check password protection
+    if crate::password::has_password(&path) {
+        use actix_web::http::header::AUTHORIZATION;
+
+        let password = request
+            .headers()
+            .get(AUTHORIZATION)
+            .and_then(|v| v.to_str().ok())
+            .and_then(extract_password_from_auth)
+            .ok_or_else(|| error::ErrorNotFound("file is not found or expired :(\n"))?;
+
+        if !crate::password::verify_file_password(&path, &password)
+            .map_err(|e| error::ErrorInternalServerError(format!("password verification: {}", e)))?
+        {
+            // Same error as missing file (prevents enumeration)
+            return Err(error::ErrorNotFound("file is not found or expired :(\n"));
+        }
+    }
+
     match paste_type {
-        PasteType::File | PasteType::RemoteFile | PasteType::Oneshot => {
+        PasteType::File | PasteType::RemoteFile | PasteType::Oneshot | PasteType::ProtectedFile => {
             let should_download = options.map(|v| v.download).unwrap_or(false);
 
             let mut mime_type = if should_download {
@@ -220,8 +263,13 @@ async fn delete(
     if !path.is_file() || !path.exists() {
         return Err(error::ErrorNotFound("file is not found or expired :(\n"));
     }
-    match fs::remove_file(path) {
-        Ok(_) => info!("deleted file: {:?}", file.to_string()),
+
+    // Delete content file first, then password (prevents unprotected window)
+    match fs::remove_file(&path) {
+        Ok(_) => {
+            info!("deleted file: {:?}", file.to_string());
+            crate::password::delete_password_file(&path).ok();
+        }
         Err(e) => {
             error!("cannot delete file: {}", e);
             return Err(error::ErrorInternalServerError("cannot delete file"));
@@ -303,6 +351,7 @@ async fn upload(
             if paste_type != PasteType::Oneshot
                 && paste_type != PasteType::RemoteFile
                 && paste_type != PasteType::OneshotUrl
+                && paste_type != PasteType::ProtectedFile
                 && expiry_date.is_none()
                 && !config
                     .read()
@@ -333,8 +382,8 @@ async fn upload(
                 data: bytes.to_vec(),
                 type_: paste_type,
             };
-            let mut file_name = match paste.type_ {
-                PasteType::File | PasteType::Oneshot => {
+            let result = match paste.type_ {
+                PasteType::File | PasteType::Oneshot | PasteType::ProtectedFile => {
                     let config = config
                         .read()
                         .map_err(|_| error::ErrorInternalServerError("cannot acquire config"))?;
@@ -357,6 +406,10 @@ async fn upload(
                     paste.store_url(expiry_date, header_filename, &config)?
                 }
             };
+
+            let mut file_name = result.filename;
+            let password = result.password;
+
             info!(
                 "{} ({}) is uploaded from {}",
                 file_name,
@@ -371,7 +424,11 @@ async fn upload(
             if let Some(handle_spaces_config) = config.server.handle_spaces {
                 file_name = handle_spaces_config.process_filename(&file_name);
             }
-            urls.push(format!("{server_url}/{file_name}\n"));
+            if let Some(pwd) = password {
+                urls.push(format!("{server_url}/{file_name}\nPassword: {pwd}\n"));
+            } else {
+                urls.push(format!("{server_url}/{file_name}\n"));
+            }
         } else {
             warn!("{} sent an invalid form field", host);
             return Err(error::ErrorBadRequest("invalid form field"));
@@ -835,6 +892,63 @@ mod tests {
     }
 
     #[actix_web::test]
+    async fn test_list_excludes_password_files() -> Result<(), Error> {
+        let mut config = Config::default();
+        config.server.expose_list = Some(true);
+
+        let test_upload_dir = "test_upload_protected_list";
+        // Clean up from any previous test runs
+        let _ = fs::remove_dir_all(test_upload_dir);
+        fs::create_dir(test_upload_dir)?;
+        config.server.upload_path = PathBuf::from(test_upload_dir);
+
+        // Create protected subdirectory
+        fs::create_dir(PathBuf::from(test_upload_dir).join("protected"))?;
+
+        let app = test::init_service(
+            App::new()
+                .app_data(Data::new(RwLock::new(config)))
+                .app_data(Data::new(Client::default()))
+                .configure(configure_routes),
+        )
+        .await;
+
+        let filename = "secret.txt";
+        let timestamp = util::get_system_time()?.as_secs().to_string();
+
+        // Upload a protected file (creates both secret.txt and secret.txt.password in protected/ subdir)
+        test::call_service(
+            &app,
+            get_multipart_request(&timestamp, "protected", filename).to_request(),
+        )
+        .await;
+
+        // Verify both files exist in protected/ subdirectory
+        let main_file = PathBuf::from(test_upload_dir)
+            .join("protected")
+            .join(filename);
+        let password_file = PathBuf::from(test_upload_dir)
+            .join("protected")
+            .join(format!("{}.password", filename));
+        assert!(main_file.exists());
+        assert!(password_file.exists());
+
+        // Call /list endpoint (reads root directory only)
+        let request = TestRequest::default()
+            .insert_header(("content-type", "text/plain"))
+            .uri("/list")
+            .to_request();
+        let result: Vec<ListItem> = test::call_and_read_body_json(&app, request).await;
+
+        // Should return 0 files (protected files are in subdirectory, not shown in root listing)
+        assert_eq!(result.len(), 0);
+
+        fs::remove_dir_all(test_upload_dir)?;
+
+        Ok(())
+    }
+
+    #[actix_web::test]
     async fn test_auth() -> Result<(), Error> {
         let mut config = Config::default();
         config.server.auth_tokens = Some(["test".to_string()].into());
@@ -910,6 +1024,9 @@ mod tests {
 
         let path = PathBuf::from(file_name);
         assert!(!path.exists());
+
+        let password_path = PathBuf::from(format!("{}.password", file_name));
+        assert!(!password_path.exists(), "password file should be deleted");
 
         Ok(())
     }
@@ -1465,6 +1582,179 @@ mod tests {
 
         // Cleanup
         fs::remove_dir_all(url_upload_path)?;
+
+        Ok(())
+    }
+
+    #[actix_web::test]
+    async fn test_upload_protected_file() -> Result<(), Error> {
+        let test_upload_dir = "test_upload_protected";
+        fs::create_dir(test_upload_dir)?;
+
+        let mut config = Config::default();
+        config.server.upload_path = PathBuf::from(test_upload_dir);
+
+        let app = test::init_service(
+            App::new()
+                .app_data(Data::new(RwLock::new(config.clone())))
+                .app_data(Data::new(Client::default()))
+                .configure(configure_routes),
+        )
+        .await;
+
+        let protected_upload_path = PasteType::ProtectedFile
+            .get_path(&config.server.upload_path)
+            .expect("Bad upload path");
+        fs::create_dir_all(&protected_upload_path)?;
+
+        let file_name = "protected.txt";
+        let file_content = "secret content";
+
+        // Upload protected file
+        let response = test::call_service(
+            &app,
+            get_multipart_request(file_content, "protected", file_name).to_request(),
+        )
+        .await;
+
+        assert_eq!(StatusCode::OK, response.status());
+        let body = response.into_body();
+        let body_bytes = actix_web::body::to_bytes(body).await?;
+        let body_text = str::from_utf8(&body_bytes)?;
+
+        // Extract URL and password from response
+        let lines: Vec<&str> = body_text.lines().collect();
+        assert_eq!(2, lines.len(), "Expected URL and password in response");
+        assert!(
+            lines[0].contains(file_name),
+            "First line should contain URL"
+        );
+        assert!(
+            lines[1].starts_with("Password: "),
+            "Second line should contain password"
+        );
+
+        let password = lines[1]
+            .strip_prefix("Password: ")
+            .expect("Failed to extract password")
+            .to_string();
+
+        // Access without authorization header -> 404
+        let serve_request = TestRequest::get()
+            .uri(&format!("/{file_name}"))
+            .to_request();
+        let response = test::call_service(&app, serve_request).await;
+        assert_eq!(StatusCode::NOT_FOUND, response.status());
+
+        // Access with wrong password (Bearer) -> 404
+        let serve_request = TestRequest::get()
+            .uri(&format!("/{file_name}"))
+            .insert_header((AUTHORIZATION, "Bearer wrongpassword"))
+            .to_request();
+        let response = test::call_service(&app, serve_request).await;
+        assert_eq!(StatusCode::NOT_FOUND, response.status());
+
+        // Access with wrong password (Basic Auth) -> 404
+        let wrong_basic = format!(
+            "Basic {}",
+            base64::Engine::encode(
+                &base64::engine::general_purpose::STANDARD,
+                b"user:wrongpassword"
+            )
+        );
+        let serve_request = TestRequest::get()
+            .uri(&format!("/{file_name}"))
+            .insert_header((AUTHORIZATION, wrong_basic))
+            .to_request();
+        let response = test::call_service(&app, serve_request).await;
+        assert_eq!(StatusCode::NOT_FOUND, response.status());
+
+        // Access with correct password (Bearer) -> 200
+        let serve_request = TestRequest::get()
+            .uri(&format!("/{file_name}"))
+            .insert_header((AUTHORIZATION, format!("Bearer {}", password)))
+            .to_request();
+        let response = test::call_service(&app, serve_request).await;
+        assert_eq!(StatusCode::OK, response.status());
+        assert_body(response.into_body(), file_content).await?;
+
+        // Access with correct password (Basic Auth) -> 200
+        let correct_basic = format!(
+            "Basic {}",
+            base64::Engine::encode(
+                &base64::engine::general_purpose::STANDARD,
+                format!("user:{}", password).as_bytes()
+            )
+        );
+        let serve_request = TestRequest::get()
+            .uri(&format!("/{file_name}"))
+            .insert_header((AUTHORIZATION, correct_basic))
+            .to_request();
+        let response = test::call_service(&app, serve_request).await;
+        assert_eq!(StatusCode::OK, response.status());
+        assert_body(response.into_body(), file_content).await?;
+
+        // Cleanup
+        fs::remove_dir_all(test_upload_dir)?;
+
+        Ok(())
+    }
+
+    #[actix_web::test]
+    async fn test_protected_file_enumeration_prevention() -> Result<(), Error> {
+        let test_upload_dir = "test_upload_enum";
+        fs::create_dir(test_upload_dir)?;
+
+        let mut config = Config::default();
+        config.server.upload_path = PathBuf::from(test_upload_dir);
+
+        let app = test::init_service(
+            App::new()
+                .app_data(Data::new(RwLock::new(config.clone())))
+                .app_data(Data::new(Client::default()))
+                .configure(configure_routes),
+        )
+        .await;
+
+        let protected_upload_path = PasteType::ProtectedFile
+            .get_path(&config.server.upload_path)
+            .expect("Bad upload path");
+        fs::create_dir_all(&protected_upload_path)?;
+
+        // Test that both missing files and protected files return same error code
+        // This prevents attackers from enumerating files
+
+        // Request non-existent file -> 404
+        let serve_request = TestRequest::get().uri("/nonexistent.txt").to_request();
+        let response = test::call_service(&app, serve_request).await;
+        assert_eq!(StatusCode::NOT_FOUND, response.status());
+
+        // Upload protected file
+        let file_name = "protected_enum.txt";
+        let response = test::call_service(
+            &app,
+            get_multipart_request("content", "protected", file_name).to_request(),
+        )
+        .await;
+        assert_eq!(StatusCode::OK, response.status());
+
+        // Request protected file without auth -> 404 (same as non-existent)
+        let serve_request = TestRequest::get()
+            .uri(&format!("/{file_name}"))
+            .to_request();
+        let response = test::call_service(&app, serve_request).await;
+        assert_eq!(StatusCode::NOT_FOUND, response.status());
+
+        // Request protected file with wrong password -> 404 (same as non-existent)
+        let serve_request = TestRequest::get()
+            .uri(&format!("/{file_name}"))
+            .insert_header((AUTHORIZATION, "Bearer wrongpassword"))
+            .to_request();
+        let response = test::call_service(&app, serve_request).await;
+        assert_eq!(StatusCode::NOT_FOUND, response.status());
+
+        // Cleanup
+        fs::remove_dir_all(test_upload_dir)?;
 
         Ok(())
     }

--- a/src/server.rs
+++ b/src/server.rs
@@ -145,7 +145,7 @@ async fn serve(
             .ok_or_else(|| error::ErrorNotFound("file is not found or expired :(\n"))?;
 
         if !crate::password::verify_file_password(&path, &password)
-            .map_err(|e| error::ErrorInternalServerError(format!("password verification: {}", e)))?
+            .map_err(|e| error::ErrorInternalServerError(format!("password verification: {e}")))?
         {
             // Same error as missing file (prevents enumeration)
             return Err(error::ErrorNotFound("file is not found or expired :(\n"));
@@ -929,7 +929,7 @@ mod tests {
             .join(filename);
         let password_file = PathBuf::from(test_upload_dir)
             .join("protected")
-            .join(format!("{}.password", filename));
+            .join(format!("{filename}.password"));
         assert!(main_file.exists());
         assert!(password_file.exists());
 
@@ -1025,7 +1025,7 @@ mod tests {
         let path = PathBuf::from(file_name);
         assert!(!path.exists());
 
-        let password_path = PathBuf::from(format!("{}.password", file_name));
+        let password_path = PathBuf::from(format!("{file_name}.password"));
         assert!(!password_path.exists(), "password file should be deleted");
 
         Ok(())
@@ -1672,7 +1672,7 @@ mod tests {
         // Access with correct password (Bearer) -> 200
         let serve_request = TestRequest::get()
             .uri(&format!("/{file_name}"))
-            .insert_header((AUTHORIZATION, format!("Bearer {}", password)))
+            .insert_header((AUTHORIZATION, format!("Bearer {password}")))
             .to_request();
         let response = test::call_service(&app, serve_request).await;
         assert_eq!(StatusCode::OK, response.status());
@@ -1683,7 +1683,7 @@ mod tests {
             "Basic {}",
             base64::Engine::encode(
                 &base64::engine::general_purpose::STANDARD,
-                format!("user:{}", password).as_bytes()
+                format!("user:{password}").as_bytes()
             )
         );
         let serve_request = TestRequest::get()

--- a/src/server.rs
+++ b/src/server.rs
@@ -259,7 +259,14 @@ async fn delete(
     let config = config
         .read()
         .map_err(|_| error::ErrorInternalServerError("cannot acquire config"))?;
-    let path = util::glob_match_file(safe_path_join(&config.server.upload_path, &*file)?)?;
+    let mut path = util::glob_match_file(safe_path_join(&config.server.upload_path, &*file)?)?;
+    if !path.is_file() || !path.exists() {
+        let protected_path = safe_path_join(
+            PasteType::ProtectedFile.get_path(&config.server.upload_path)?,
+            &*file,
+        )?;
+        path = util::glob_match_file(protected_path)?;
+    }
     if !path.is_file() || !path.exists() {
         return Err(error::ErrorNotFound("file is not found or expired :(\n"));
     }
@@ -1027,6 +1034,58 @@ mod tests {
 
         let password_path = PathBuf::from(format!("{file_name}.password"));
         assert!(!password_path.exists(), "password file should be deleted");
+
+        Ok(())
+    }
+
+    #[actix_web::test]
+    async fn test_delete_protected_file() -> Result<(), Error> {
+        let mut config = Config::default();
+        config.server.delete_tokens = Some(["test".to_string()].into());
+        config.server.upload_path = env::current_dir()?;
+
+        let protected_upload_path = PasteType::ProtectedFile
+            .get_path(&config.server.upload_path)
+            .expect("cannot get protected file path");
+        fs::create_dir_all(&protected_upload_path)?;
+
+        let app = test::init_service(
+            App::new()
+                .app_data(Data::new(RwLock::new(config)))
+                .app_data(Data::new(Client::default()))
+                .configure(configure_routes),
+        )
+        .await;
+
+        let file_name = "test_protected_delete.txt";
+        let timestamp = util::get_system_time()?.as_secs().to_string();
+        test::call_service(
+            &app,
+            get_multipart_request(&timestamp, "protected", file_name).to_request(),
+        )
+        .await;
+
+        let path = protected_upload_path.join(file_name);
+        let password_path = protected_upload_path.join(format!("{file_name}.password"));
+        assert!(path.exists());
+        assert!(password_path.exists());
+
+        let request = TestRequest::delete()
+            .insert_header((AUTHORIZATION, header::HeaderValue::from_static("test")))
+            .uri(&format!("/{file_name}"))
+            .to_request();
+        let response = test::call_service(&app, request).await;
+
+        assert_eq!(StatusCode::OK, response.status());
+        assert_body(response.into_body(), "file deleted\n").await?;
+
+        assert!(!path.exists());
+        assert!(
+            !password_path.exists(),
+            "password file should be deleted with the content file"
+        );
+
+        fs::remove_dir(protected_upload_path)?;
 
         Ok(())
     }

--- a/src/util.rs
+++ b/src/util.rs
@@ -108,6 +108,7 @@ pub fn get_expired_files(base_path: &Path) -> Vec<PathBuf> {
         PasteType::Oneshot,
         PasteType::Url,
         PasteType::OneshotUrl,
+        PasteType::ProtectedFile,
     ]
     .into_iter()
     .filter_map(|v| v.get_path(base_path).ok())
@@ -127,6 +128,23 @@ pub fn get_expired_files(base_path: &Path) -> Vec<PathBuf> {
         }
     })
     .collect()
+}
+
+/// Returns orphaned .password files (main file missing)
+pub fn get_orphaned_password_files(base_path: &Path) -> Vec<PathBuf> {
+    // Search both root and protected subdirectory
+    [base_path.to_path_buf(), base_path.join("protected")]
+        .into_iter()
+        .filter_map(|dir| glob(&dir.join("*.password").to_string_lossy()).ok())
+        .flat_map(|g| g.filter_map(|v| v.ok()))
+        .filter(|password_path| {
+            password_path
+                .file_stem()
+                .and_then(|stem| password_path.parent().map(|p| p.join(stem)))
+                .map(|main_path| !main_path.exists())
+                .unwrap_or(false)
+        })
+        .collect()
 }
 
 /// Returns the SHA256 digest of the given input.
@@ -371,6 +389,42 @@ mod tests {
         );
         fs::remove_file(path)?;
         assert_eq!(Vec::<PathBuf>::new(), get_expired_files(&current_dir));
+        Ok(())
+    }
+
+    #[test]
+    fn test_get_orphaned_password_files() -> Result<(), ActixError> {
+        let test_dir = env::temp_dir().join("rustypaste_orphan_test");
+        let protected_dir = test_dir.join("protected");
+
+        // Cleanup from previous runs
+        let _ = fs::remove_dir_all(&test_dir);
+
+        fs::create_dir_all(&protected_dir)?;
+
+        // Create orphaned password file in root
+        let orphan_root = test_dir.join("orphan_root.txt.password");
+        fs::write(&orphan_root, "hash")?;
+
+        // Create orphaned password file in protected/
+        let orphan_protected = protected_dir.join("orphan_protected.txt.password");
+        fs::write(&orphan_protected, "hash")?;
+
+        // Create non-orphaned password file (has main file)
+        let main_file = protected_dir.join("valid.txt");
+        let valid_password = protected_dir.join("valid.txt.password");
+        fs::write(&main_file, "content")?;
+        fs::write(&valid_password, "hash")?;
+
+        let orphans = get_orphaned_password_files(&test_dir);
+
+        // Should find both orphans, not the valid one
+        assert_eq!(2, orphans.len());
+        assert!(orphans.contains(&orphan_root));
+        assert!(orphans.contains(&orphan_protected));
+        assert!(!orphans.contains(&valid_password));
+
+        fs::remove_dir_all(&test_dir)?;
         Ok(())
     }
 


### PR DESCRIPTION
## Description

This PR adds password-protected file uploads to rustypaste. Users upload files with the `protected` form field, the server generates a random password and returns it alongside the URL, and downloads require that password via Authorization header.

I tried to follow the existing paste type patterns closely. Passwords are hashed with Argon2id and stored in sidecar files (`filename.txt.password`) alongside the uploaded content. This avoids extended attributes or database dependencies while keeping cleanup straightforward.

File operations use careful ordering to prevent unprotected content exposure. Creation stores password hashes before writing content files, and reverse that order for deletion. If either operation is interrupted, worst case is an orphaned password file with no exposed content. The cleanup routine removes these orphaned files when detected.

## Motivation and Context

Sharing sensitive files requires more protection than obscurity through random URLs. Password protection adds a basic authentication layer while keeping rustypaste's simplicity intact.

This implementation aims to fit naturally into the existing codebase rather than introduce new architectural patterns. The sidecar file approach mirrors how expiration timestamps are handled and makes cleanup deterministic.

## Design Decisions

**Storage location:** Protected files are stored in a dedicated `protected/` subdirectory, following the same pattern as oneshot and URL paste types. This provides natural isolation and simplifies the codebase by eliminating the need for special filtering logic in the list endpoint (my first approach).

## How Has This Been Tested?

### Manual Testing

Tested locally against the development server:

- Upload with `curl -F "protected=@file.txt"` returns URL and password
- Download with Bearer token succeeds: `curl -H "Authorization: Bearer <password>"`
- Download with Basic Auth succeeds: `curl -u "user:<password>"`
- All failure modes return 404 to prevent enumeration (missing auth, wrong password, or non-existent file all return identical responses)
- Cleanup removes both main file and password sidecar
- Orphaned password files are identified and removed

### Automated Tests

**Unit tests** (`src/password.rs`):
- `test_password_hashing` - Verifies hash generation and password verification against Argon2
- `test_password_file_path` - Tests path transformation logic for password sidecar files
- `test_password_file_path_invalid_utf8` - Validates error handling for paths with invalid UTF-8 sequences
- `test_store_and_verify_password` - Full roundtrip test covering storage, verification, and cleanup

**Integration tests** (`src/server.rs`):
- `test_upload_protected_file` - Tests upload/download flow with all authentication scenarios (missing auth, wrong password via Bearer/Basic, correct password via Bearer/Basic)
- `test_protected_file_enumeration_prevention` - Verifies all authentication failures return identical 404 responses to prevent file enumeration
- `test_list_excludes_password_files` - Confirms protected files and their password sidecars are hidden from the list endpoint

Tests cover the critical path and error handling for password-protected files. All existing tests pass.

## Changelog Entry

### Added

- Password-protected file uploads via `protected` form field
  - Server generates 24-character alphanumeric passwords
  - Passwords hashed with Argon2id (19MB memory, 2 iterations)
  - Download requires password via Authorization header (Bearer or Basic Auth)
  - All authentication failures return 404 to prevent file enumeration
  - Protected files hidden from list endpoint to prevent enumeration
  - Cleanup handles orphaned password files

## Types of Changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

---

**Note to maintainer:** I'm still building familiarity with Rust, so if there are patterns here that could be more idiomatic or align better with the project's conventions, I'm happy to revise. Figuring out the tests needed to be run single-threaded was an interesting experience. I thought I had broken everything before I dug into the `ci` workflow to see how they ran 'for real'.
