### PR TITLE
refactor: address security issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,15 @@ There are 2 options for setting multiple auth tokens:
 
 See [config.toml](./config.toml) for configuration options.
 
+#### MIME handling
+
+rustypaste determines a file's MIME type from its extension (with optional overrides) and serves
+text-like types as `text/plain; charset=utf-8` to avoid script execution.
+
+- `[paste].mime_override` lets you override MIME types by filename regex.
+- `[paste].mime_blacklist` blocks uploads of specific MIME types.
+- `[paste].text_mime_overrides` forces additional MIME types to be rendered as plaintext.
+
 #### List endpoint
 
 Set `expose_list` to true in [config.toml](./config.toml) to be able to retrieve a JSON formatted list of files in your uploads directory. This will not include oneshot files, oneshot URLs, or URLs.

--- a/README.md
+++ b/README.md
@@ -312,7 +312,7 @@ text-like types as `text/plain; charset=utf-8` to avoid script execution.
 
 - `[paste].mime_override` lets you override MIME types by filename regex.
 - `[paste].mime_blacklist` blocks uploads of specific MIME types.
-- `[paste].text_mime_overrides` forces additional MIME types to be rendered as plaintext.
+- `[paste].text_mime_overrides` forces additional detected/guessed MIME types to be rendered as plaintext (unlike `mime_override` which matches by filename regex, this matches the content's actual MIME type).
 
 #### List endpoint
 

--- a/config.toml
+++ b/config.toml
@@ -66,6 +66,11 @@ mime_blacklist = [
   "application/java-archive",
   "application/java-vm",
 ]
+# Additional MIME types to render as text/plain when serving files.
+#text_mime_overrides = [
+#  "application/toml",
+#  "application/x-yaml",
+#]
 duplicate_files = true
 # default_expiry = "1h"
 delete_expired_files = { enabled = true, interval = "1h" }

--- a/config.toml
+++ b/config.toml
@@ -67,10 +67,13 @@ mime_blacklist = [
   "application/java-vm",
 ]
 # Additional MIME types to render as text/plain when serving files.
-#text_mime_overrides = [
-#  "application/toml",
-#  "application/x-yaml",
-#]
+text_mime_overrides = [
+  "application/toml",
+  "application/yaml",
+  "application/x-yaml",
+]
+# Enable security hardening headers (X-Content-Type-Options, Content-Security-Policy).
+#hardening = false
 duplicate_files = true
 # default_expiry = "1h"
 delete_expired_files = { enabled = true, interval = "1h" }

--- a/src/config.rs
+++ b/src/config.rs
@@ -114,6 +114,9 @@ pub struct PasteConfig {
     /// Media type blacklist.
     #[serde(default)]
     pub mime_blacklist: Vec<String>,
+    /// Additional MIME types to render as text/plain when serving files.
+    #[serde(default)]
+    pub text_mime_overrides: Vec<String>,
     /// Allow duplicate uploads.
     pub duplicate_files: Option<bool>,
     /// Default expiry time.

--- a/src/config.rs
+++ b/src/config.rs
@@ -68,6 +68,8 @@ pub struct ServerConfig {
     pub expose_list: Option<bool>,
     /// Authentication tokens for deleting.
     pub delete_tokens: Option<HashSet<String>>,
+    /// Enable security hardening headers (X-Content-Type-Options, Content-Security-Policy).
+    pub hardening: Option<bool>,
 }
 
 /// Enum representing different strategies for handling spaces in filenames.

--- a/src/paste.rs
+++ b/src/paste.rs
@@ -232,7 +232,10 @@ impl Paste {
         .await
         {
             Ok(Ok(())) => {}
-            Ok(Err(e)) => return Err(error::ErrorBadRequest(e.to_string())),
+            Ok(Err(e)) => {
+                warn!("URL validation failed for {}: {}", url, e);
+                return Err(error::ErrorBadRequest("invalid remote URL\n"));
+            }
             Err(e) => return Err(error::ErrorInternalServerError(e.to_string())),
         }
         let file_name = url

--- a/src/paste.rs
+++ b/src/paste.rs
@@ -227,10 +227,8 @@ impl Paste {
     ) -> Result<String, Error> {
         let data = str::from_utf8(&self.data).map_err(error::ErrorBadRequest)?;
         let url = Url::parse(data).map_err(error::ErrorBadRequest)?;
-        match web::block({
-            let url = url.clone();
-            move || util::validate_remote_url(&url)
-        })
+        let url_clone = url.clone();
+        match web::block(move || util::validate_remote_url(&url_clone))
         .await
         {
             Ok(Ok(())) => {}

--- a/src/paste.rs
+++ b/src/paste.rs
@@ -228,9 +228,7 @@ impl Paste {
         let data = str::from_utf8(&self.data).map_err(error::ErrorBadRequest)?;
         let url = Url::parse(data).map_err(error::ErrorBadRequest)?;
         let url_clone = url.clone();
-        match web::block(move || util::validate_remote_url(&url_clone))
-        .await
-        {
+        match web::block(move || util::validate_remote_url(&url_clone)).await {
             Ok(Ok(())) => {}
             Ok(Err(e)) => {
                 warn!("URL validation failed for {}: {}", url, e);

--- a/src/server.rs
+++ b/src/server.rs
@@ -493,6 +493,7 @@ mod tests {
     use std::io::Write;
     use std::path::PathBuf;
     use std::str;
+    use std::str::FromStr;
     use std::thread;
     use std::time::Duration;
 
@@ -532,6 +533,51 @@ mod tests {
         } else {
             Err(error::ErrorInternalServerError("unexpected body type"))
         }
+    }
+
+    #[test]
+    fn test_is_text_like_mime_defaults() {
+        let overrides = Vec::<String>::new();
+        assert!(is_text_like_mime(
+            &mime::Mime::from_str("text/plain").expect("invalid mime"),
+            &overrides
+        ));
+        assert!(is_text_like_mime(
+            &mime::Mime::from_str("application/atom+xml").expect("invalid mime"),
+            &overrides
+        ));
+        assert!(is_text_like_mime(
+            &mime::Mime::from_str("application/problem+json").expect("invalid mime"),
+            &overrides
+        ));
+        assert!(is_text_like_mime(
+            &mime::Mime::from_str("image/svg+xml").expect("invalid mime"),
+            &overrides
+        ));
+        assert!(!is_text_like_mime(
+            &mime::Mime::from_str("application/octet-stream").expect("invalid mime"),
+            &overrides
+        ));
+    }
+
+    #[test]
+    fn test_is_text_like_mime_overrides() {
+        let overrides = vec![
+            String::from("application/toml"),
+            String::from("application/x-yaml"),
+        ];
+        assert!(is_text_like_mime(
+            &mime::Mime::from_str("application/toml").expect("invalid mime"),
+            &overrides
+        ));
+        assert!(is_text_like_mime(
+            &mime::Mime::from_str("application/x-yaml").expect("invalid mime"),
+            &overrides
+        ));
+        assert!(!is_text_like_mime(
+            &mime::Mime::from_str("application/pdf").expect("invalid mime"),
+            &overrides
+        ));
     }
 
     #[actix_web::test]

--- a/src/server.rs
+++ b/src/server.rs
@@ -185,18 +185,9 @@ fn is_text_like_mime(mime_type: &mime::Mime, overrides: &[String]) -> bool {
         "application/javascript"
             | "application/ecmascript"
             | "application/json"
-            | "application/geo+json"
-            | "application/ld+json"
-            | "application/manifest+json"
-            | "application/problem+json"
-            | "application/rss+xml"
-            | "application/atom+xml"
             | "application/x-www-form-urlencoded"
             | "application/x-javascript"
             | "application/xml"
-            | "application/xhtml+xml"
-            | "image/svg+xml"
-            | "text/xml"
     )
 }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -128,7 +128,9 @@ async fn serve(
                 .set_content_type(mime_type)
                 .prefer_utf8(true)
                 .into_response(&request);
-            apply_security_headers(&mut response);
+            if config.server.hardening.unwrap_or(false) {
+                apply_security_headers(&mut response);
+            }
             if paste_type.is_oneshot() {
                 fs::rename(
                     &path,
@@ -157,6 +159,11 @@ async fn serve(
     }
 }
 
+/// Adds security hardening headers to the response.
+///
+/// Sets `X-Content-Type-Options: nosniff` to prevent MIME sniffing and
+/// `Content-Security-Policy: default-src 'none'; sandbox` to restrict
+/// script execution and embedding.
 fn apply_security_headers(response: &mut HttpResponse) {
     response
         .headers_mut()
@@ -167,6 +174,14 @@ fn apply_security_headers(response: &mut HttpResponse) {
     );
 }
 
+/// Returns `true` if the given MIME type represents text-like content that
+/// should be rendered as `text/plain` instead of being downloaded.
+///
+/// A MIME type is considered text-like if any of the following hold:
+/// - Its type is `text` (e.g. `text/html`, `text/x-shellscript`)
+/// - It has a `+xml` or `+json` structured syntax suffix
+/// - It matches one of the user-configured `overrides`
+/// - It is a known text-like `application/` type (e.g. `application/json`, `application/xml`)
 fn is_text_like_mime(mime_type: &mime::Mime, overrides: &[String]) -> bool {
     if mime_type.type_() == mime::TEXT {
         return true;

--- a/src/util.rs
+++ b/src/util.rs
@@ -212,7 +212,6 @@ fn is_disallowed_ip(ip: IpAddr) -> bool {
 fn is_disallowed_ipv4(v4: std::net::Ipv4Addr) -> bool {
     let o = v4.octets();
     if v4.is_loopback()
-        || v4.is_private()
         || v4.is_link_local()
         || v4.is_multicast()
         || v4.is_broadcast()

--- a/src/util.rs
+++ b/src/util.rs
@@ -400,18 +400,6 @@ mod tests {
     }
 
     #[test]
-    fn test_validate_remote_url_rejects_private_ip() {
-        for ip in &["10.0.0.1", "192.168.1.1", "172.16.0.1"] {
-            let url = Url::parse(&format!("http://{ip}/file.txt")).unwrap();
-            let err = validate_remote_url(&url).unwrap_err();
-            assert!(
-                err.to_string().contains("disallowed address"),
-                "expected {ip} to be rejected"
-            );
-        }
-    }
-
-    #[test]
     fn test_validate_remote_url_rejects_unresolvable() {
         let url =
             Url::parse("http://this-domain-should-not-exist-xyz123.invalid/file.txt").unwrap();
@@ -423,10 +411,6 @@ mod tests {
         use std::net::Ipv4Addr;
         // Loopback
         assert!(is_disallowed_ipv4(Ipv4Addr::new(127, 0, 0, 1)));
-        // Private ranges
-        assert!(is_disallowed_ipv4(Ipv4Addr::new(10, 0, 0, 1)));
-        assert!(is_disallowed_ipv4(Ipv4Addr::new(172, 16, 0, 1)));
-        assert!(is_disallowed_ipv4(Ipv4Addr::new(192, 168, 0, 1)));
         // Link-local
         assert!(is_disallowed_ipv4(Ipv4Addr::new(169, 254, 1, 1)));
         // Multicast
@@ -466,10 +450,6 @@ mod tests {
         // IPv4-mapped loopback
         assert!(is_disallowed_ipv6(Ipv6Addr::new(
             0, 0, 0, 0, 0, 0xffff, 0x7f00, 0x0001
-        )));
-        // IPv4-mapped private
-        assert!(is_disallowed_ipv6(Ipv6Addr::new(
-            0, 0, 0, 0, 0, 0xffff, 0x0a00, 0x0001
         )));
         // Documentation 2001:db8::/32
         assert!(is_disallowed_ipv6(Ipv6Addr::new(

--- a/src/util.rs
+++ b/src/util.rs
@@ -226,6 +226,8 @@ fn is_disallowed_ipv4(v4: std::net::Ipv4Addr) -> bool {
         return true;
     }
     // Benchmarking: 198.18.0.0/15
+    // TODO: Replace with v4.is_benchmarking() when stabilised.
+    // See: https://doc.rust-lang.org/std/net/enum.IpAddr.html#method.is_benchmarking
     if o[0] == 198 && (o[1] == 18 || o[1] == 19) {
         return true;
     }
@@ -252,7 +254,6 @@ fn is_disallowed_ipv6(v6: std::net::Ipv6Addr) -> bool {
         return is_disallowed_ipv4(v4);
     }
     if v6.is_multicast()
-        || v6.is_multicast()
         || v6.is_unique_local()
         || v6.is_unicast_link_local()
     {
@@ -261,6 +262,10 @@ fn is_disallowed_ipv6(v6: std::net::Ipv6Addr) -> bool {
     let seg = v6.segments();
     // Documentation: 2001:db8::/32
     if seg[0] == 0x2001 && seg[1] == 0x0db8 {
+        return true;
+    }
+    // Documentation: 3fff::/20 (RFC 9637)
+    if seg[0] == 0x3fff {
         return true;
     }
     false
@@ -467,6 +472,9 @@ mod tests {
         assert!(is_disallowed_ipv6(Ipv6Addr::new(0, 0, 0, 0, 0, 0xffff, 0x0a00, 0x0001)));
         // Documentation 2001:db8::/32
         assert!(is_disallowed_ipv6(Ipv6Addr::new(0x2001, 0x0db8, 0, 0, 0, 0, 0, 1)));
+        // Documentation 3fff::/20 (RFC 9637)
+        assert!(is_disallowed_ipv6(Ipv6Addr::new(0x3fff, 0, 0, 0, 0, 0, 0, 1)));
+        assert!(is_disallowed_ipv6(Ipv6Addr::new(0x3fff, 0x0fff, 0, 0, 0, 0, 0, 1)));
         // Unique local (fc00::/7)
         assert!(is_disallowed_ipv6(Ipv6Addr::new(0xfc00, 0, 0, 0, 0, 0, 0, 1)));
         assert!(is_disallowed_ipv6(Ipv6Addr::new(0xfd00, 0, 0, 0, 0, 0, 0, 1)));

--- a/src/util.rs
+++ b/src/util.rs
@@ -252,10 +252,7 @@ fn is_disallowed_ipv6(v6: std::net::Ipv6Addr) -> bool {
     if let Some(v4) = v6.to_ipv4() {
         return is_disallowed_ipv4(v4);
     }
-    if v6.is_multicast()
-        || v6.is_unique_local()
-        || v6.is_unicast_link_local()
-    {
+    if v6.is_multicast() || v6.is_unique_local() || v6.is_unicast_link_local() {
         return true;
     }
     let seg = v6.segments();
@@ -466,21 +463,39 @@ mod tests {
         // Unspecified
         assert!(is_disallowed_ipv6(Ipv6Addr::UNSPECIFIED));
         // IPv4-mapped loopback
-        assert!(is_disallowed_ipv6(Ipv6Addr::new(0, 0, 0, 0, 0, 0xffff, 0x7f00, 0x0001)));
+        assert!(is_disallowed_ipv6(Ipv6Addr::new(
+            0, 0, 0, 0, 0, 0xffff, 0x7f00, 0x0001
+        )));
         // IPv4-mapped private
-        assert!(is_disallowed_ipv6(Ipv6Addr::new(0, 0, 0, 0, 0, 0xffff, 0x0a00, 0x0001)));
+        assert!(is_disallowed_ipv6(Ipv6Addr::new(
+            0, 0, 0, 0, 0, 0xffff, 0x0a00, 0x0001
+        )));
         // Documentation 2001:db8::/32
-        assert!(is_disallowed_ipv6(Ipv6Addr::new(0x2001, 0x0db8, 0, 0, 0, 0, 0, 1)));
+        assert!(is_disallowed_ipv6(Ipv6Addr::new(
+            0x2001, 0x0db8, 0, 0, 0, 0, 0, 1
+        )));
         // Documentation 3fff::/20 (RFC 9637)
-        assert!(is_disallowed_ipv6(Ipv6Addr::new(0x3fff, 0, 0, 0, 0, 0, 0, 1)));
-        assert!(is_disallowed_ipv6(Ipv6Addr::new(0x3fff, 0x0fff, 0, 0, 0, 0, 0, 1)));
+        assert!(is_disallowed_ipv6(Ipv6Addr::new(
+            0x3fff, 0, 0, 0, 0, 0, 0, 1
+        )));
+        assert!(is_disallowed_ipv6(Ipv6Addr::new(
+            0x3fff, 0x0fff, 0, 0, 0, 0, 0, 1
+        )));
         // Unique local (fc00::/7)
-        assert!(is_disallowed_ipv6(Ipv6Addr::new(0xfc00, 0, 0, 0, 0, 0, 0, 1)));
-        assert!(is_disallowed_ipv6(Ipv6Addr::new(0xfd00, 0, 0, 0, 0, 0, 0, 1)));
+        assert!(is_disallowed_ipv6(Ipv6Addr::new(
+            0xfc00, 0, 0, 0, 0, 0, 0, 1
+        )));
+        assert!(is_disallowed_ipv6(Ipv6Addr::new(
+            0xfd00, 0, 0, 0, 0, 0, 0, 1
+        )));
         // Link-local (fe80::/10)
-        assert!(is_disallowed_ipv6(Ipv6Addr::new(0xfe80, 0, 0, 0, 0, 0, 0, 1)));
+        assert!(is_disallowed_ipv6(Ipv6Addr::new(
+            0xfe80, 0, 0, 0, 0, 0, 0, 1
+        )));
 
         // Public IPv6 should be allowed
-        assert!(!is_disallowed_ipv6(Ipv6Addr::new(0x2607, 0xf8b0, 0x4004, 0x800, 0, 0, 0, 0x200e)));
+        assert!(!is_disallowed_ipv6(Ipv6Addr::new(
+            0x2607, 0xf8b0, 0x4004, 0x800, 0, 0, 0, 0x200e
+        )));
     }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -200,6 +200,8 @@ pub fn validate_remote_url(url: &Url) -> IoResult<()> {
     Ok(())
 }
 
+/// Returns `true` if the IP address belongs to a private, reserved, or otherwise
+/// non-publicly-routable range that should not be accessed via remote URL fetching.
 fn is_disallowed_ip(ip: IpAddr) -> bool {
     match ip {
         IpAddr::V4(v4) => is_disallowed_ipv4(v4),
@@ -240,11 +242,16 @@ fn is_disallowed_ipv4(v4: std::net::Ipv4Addr) -> bool {
 }
 
 fn is_disallowed_ipv6(v6: std::net::Ipv6Addr) -> bool {
+    // Check loopback/unspecified before to_ipv4(), because ::1 maps to
+    // 0.0.0.1 and :: maps to 0.0.0.0 via to_ipv4(), which would bypass
+    // the IPv6-specific loopback/unspecified checks below.
+    if v6.is_loopback() || v6.is_unspecified() {
+        return true;
+    }
     if let Some(v4) = v6.to_ipv4() {
         return is_disallowed_ipv4(v4);
     }
-    if v6.is_loopback()
-        || v6.is_unspecified()
+    if v6.is_multicast()
         || v6.is_multicast()
         || v6.is_unique_local()
         || v6.is_unicast_link_local()
@@ -340,5 +347,133 @@ mod tests {
         assert!(safe_path_join("/foo", "/bar").is_err());
         assert!(safe_path_join("/foo/bar", "..").is_err());
         assert!(safe_path_join("/foo/bar", "../").is_err());
+    }
+
+    #[test]
+    fn test_validate_remote_url_valid_https() {
+        let url = Url::parse("https://example.com/file.txt").unwrap();
+        assert!(validate_remote_url(&url).is_ok());
+    }
+
+    #[test]
+    fn test_validate_remote_url_valid_http() {
+        let url = Url::parse("http://example.com/file.txt").unwrap();
+        assert!(validate_remote_url(&url).is_ok());
+    }
+
+    #[test]
+    fn test_validate_remote_url_rejects_ftp() {
+        let url = Url::parse("ftp://example.com/file.txt").unwrap();
+        let err = validate_remote_url(&url).unwrap_err();
+        assert_eq!(err.kind(), IoErrorKind::InvalidInput);
+        assert!(err.to_string().contains("unsupported URL scheme"));
+    }
+
+    #[test]
+    fn test_validate_remote_url_rejects_file_scheme() {
+        let url = Url::parse("file:///etc/passwd").unwrap();
+        let err = validate_remote_url(&url).unwrap_err();
+        assert!(err.to_string().contains("unsupported URL scheme"));
+    }
+
+    #[test]
+    fn test_validate_remote_url_rejects_localhost() {
+        let url = Url::parse("http://localhost/file.txt").unwrap();
+        let err = validate_remote_url(&url).unwrap_err();
+        assert!(err.to_string().contains("localhost is not allowed"));
+    }
+
+    #[test]
+    fn test_validate_remote_url_rejects_subdomain_localhost() {
+        let url = Url::parse("http://foo.localhost/file.txt").unwrap();
+        let err = validate_remote_url(&url).unwrap_err();
+        assert!(err.to_string().contains("localhost is not allowed"));
+    }
+
+    #[test]
+    fn test_validate_remote_url_rejects_loopback() {
+        let url = Url::parse("http://127.0.0.1/file.txt").unwrap();
+        let err = validate_remote_url(&url).unwrap_err();
+        assert!(err.to_string().contains("disallowed address"));
+    }
+
+    #[test]
+    fn test_validate_remote_url_rejects_private_ip() {
+        for ip in &["10.0.0.1", "192.168.1.1", "172.16.0.1"] {
+            let url = Url::parse(&format!("http://{ip}/file.txt")).unwrap();
+            let err = validate_remote_url(&url).unwrap_err();
+            assert!(
+                err.to_string().contains("disallowed address"),
+                "expected {ip} to be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn test_validate_remote_url_rejects_unresolvable() {
+        let url =
+            Url::parse("http://this-domain-should-not-exist-xyz123.invalid/file.txt").unwrap();
+        assert!(validate_remote_url(&url).is_err());
+    }
+
+    #[test]
+    fn test_is_disallowed_ipv4() {
+        use std::net::Ipv4Addr;
+        // Loopback
+        assert!(is_disallowed_ipv4(Ipv4Addr::new(127, 0, 0, 1)));
+        // Private ranges
+        assert!(is_disallowed_ipv4(Ipv4Addr::new(10, 0, 0, 1)));
+        assert!(is_disallowed_ipv4(Ipv4Addr::new(172, 16, 0, 1)));
+        assert!(is_disallowed_ipv4(Ipv4Addr::new(192, 168, 0, 1)));
+        // Link-local
+        assert!(is_disallowed_ipv4(Ipv4Addr::new(169, 254, 1, 1)));
+        // Multicast
+        assert!(is_disallowed_ipv4(Ipv4Addr::new(224, 0, 0, 1)));
+        // Broadcast
+        assert!(is_disallowed_ipv4(Ipv4Addr::new(255, 255, 255, 255)));
+        // Documentation
+        assert!(is_disallowed_ipv4(Ipv4Addr::new(192, 0, 2, 1)));
+        // Unspecified
+        assert!(is_disallowed_ipv4(Ipv4Addr::new(0, 0, 0, 0)));
+        // Carrier-grade NAT
+        assert!(is_disallowed_ipv4(Ipv4Addr::new(100, 64, 0, 1)));
+        assert!(is_disallowed_ipv4(Ipv4Addr::new(100, 127, 255, 254)));
+        // Benchmarking
+        assert!(is_disallowed_ipv4(Ipv4Addr::new(198, 18, 0, 1)));
+        assert!(is_disallowed_ipv4(Ipv4Addr::new(198, 19, 0, 1)));
+        // IETF protocol assignments
+        assert!(is_disallowed_ipv4(Ipv4Addr::new(192, 0, 0, 1)));
+        // Reserved for future use
+        assert!(is_disallowed_ipv4(Ipv4Addr::new(240, 0, 0, 1)));
+        // Metadata IP
+        assert!(is_disallowed_ipv4(Ipv4Addr::new(169, 254, 169, 254)));
+
+        // Public IPs should be allowed
+        assert!(!is_disallowed_ipv4(Ipv4Addr::new(8, 8, 8, 8)));
+        assert!(!is_disallowed_ipv4(Ipv4Addr::new(1, 1, 1, 1)));
+        assert!(!is_disallowed_ipv4(Ipv4Addr::new(93, 184, 216, 34)));
+    }
+
+    #[test]
+    fn test_is_disallowed_ipv6() {
+        use std::net::Ipv6Addr;
+        // Loopback
+        assert!(is_disallowed_ipv6(Ipv6Addr::LOCALHOST));
+        // Unspecified
+        assert!(is_disallowed_ipv6(Ipv6Addr::UNSPECIFIED));
+        // IPv4-mapped loopback
+        assert!(is_disallowed_ipv6(Ipv6Addr::new(0, 0, 0, 0, 0, 0xffff, 0x7f00, 0x0001)));
+        // IPv4-mapped private
+        assert!(is_disallowed_ipv6(Ipv6Addr::new(0, 0, 0, 0, 0, 0xffff, 0x0a00, 0x0001)));
+        // Documentation 2001:db8::/32
+        assert!(is_disallowed_ipv6(Ipv6Addr::new(0x2001, 0x0db8, 0, 0, 0, 0, 0, 1)));
+        // Unique local (fc00::/7)
+        assert!(is_disallowed_ipv6(Ipv6Addr::new(0xfc00, 0, 0, 0, 0, 0, 0, 1)));
+        assert!(is_disallowed_ipv6(Ipv6Addr::new(0xfd00, 0, 0, 0, 0, 0, 0, 1)));
+        // Link-local (fe80::/10)
+        assert!(is_disallowed_ipv6(Ipv6Addr::new(0xfe80, 0, 0, 0, 0, 0, 0, 1)));
+
+        // Public IPv6 should be allowed
+        assert!(!is_disallowed_ipv6(Ipv6Addr::new(0x2607, 0xf8b0, 0x4004, 0x800, 0, 0, 0, 0x200e)));
     }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -267,6 +267,7 @@ fn is_disallowed_ipv6(v6: std::net::Ipv6Addr) -> bool {
     false
 }
 
+#[allow(clippy::unwrap_used)]
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
As discussed on Discord there are a couple of security issues. XSS is pretty relevant, the SSRF doesn't matter as much imo.

## Description

We now serve files that are text-like as plain-text instead of preserving their original mimetype. This should be enough to prevent the XSS we had before. I also slapped on some more headers for good measure.

The mimes can be configured in the config (also added that to the README) to block uploads of specific types. Users can also force plain-text rendering on filetypes, etc.

For the SSRF issues we now check whether the target URL of remote pastes is "allowed", i.e. not our current system. Redirects stay untouched from this.

## Motivation and Context

Responsible disclosure via Discord -> should be fixed

## How Has This Been Tested?

Did some manual testing with the provided example payloads + some extra examples

## Changelog Entry
````
### Security

- Change how text-like content is served to prevent cross-site scripting
- Added `Content-Security-Policy` header
- Added validation for the remote URLs to fetch paste content from
    - It used to be possible to fetch any URL, we now disallow local IP addresses
````

## Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [x] Other: Security fixes

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
