### PR TITLE
Allow to blacklist a whole class of mime-types

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -65,6 +65,7 @@ mime_blacklist = [
   "application/x-dosexec",
   "application/java-archive",
   "application/java-vm",
+  "audio/",
 ]
 duplicate_files = true
 # default_expiry = "1h"

--- a/fixtures/test-server-mime-blacklist/config.toml
+++ b/fixtures/test-server-mime-blacklist/config.toml
@@ -7,4 +7,4 @@ upload_path = "./upload"
 random_url = { type = "petname", words = 2, separator = "-" }
 default_extension = "txt"
 duplicate_files = true
-mime_blacklist = ["text/html", "text/xml"]
+mime_blacklist = ["text/html", "text/xml", "image/"]

--- a/fixtures/test-server-mime-blacklist/test.sh
+++ b/fixtures/test-server-mime-blacklist/test.sh
@@ -6,11 +6,13 @@ setup() {
   echo "<html></html>" > file.html
   echo '<?xml version="1.0" encoding="UTF-8" standalone="no" ?>' > file.xml
   echo "$content" > file.txt
+  cp -f $(dirname $(pwd))/../img/rustypaste_logo.png file.png
 }
 
 run_test() {
   test "this file type is not permitted" = "$(curl -s -F "file=@file.html" localhost:8000)"
   test "this file type is not permitted" = "$(curl -s -F "file=@file.xml" localhost:8000)"
+  test "this file type is not permitted" = "$(curl -s -F "file=@file.png" localhost:8000)"
   test "415" = "$(curl -s -F "file=@file.xml" -w "%{response_code}" -o /dev/null localhost:8000)"
   file_url=$(curl -s -F "file=@file.txt" localhost:8000)
   test "$content" = "$(curl -s $file_url)"

--- a/src/paste.rs
+++ b/src/paste.rs
@@ -105,7 +105,9 @@ impl Paste {
         let file_type = infer::get(&self.data);
         if let Some(file_type) = file_type {
             for mime_type in &config.paste.mime_blacklist {
-                if mime_type == file_type.mime_type() {
+                if mime_type == file_type.mime_type()
+                    || (mime_type.ends_with('/') && file_type.mime_type().starts_with(mime_type))
+                {
                     return Err(error::ErrorUnsupportedMediaType(
                         "this file type is not permitted",
                     ));


### PR DESCRIPTION
This can be useful to be sure that no image is uploaded (or no binary format).

<!--- Thank you for contributing to rustypaste! -->

## Description

This PR allow to block a complete group of mimetype in the config. 

## Motivation and Context

I just installed rustypaste, and I wanted to be sure that people are not using the pastebin service to share images, cause I would rather not have the cops knock on my door if those images are illegal. But for that, I need to list all images format 1 by 1, and that's both tedious and not futureproof. Being able to say "everything that is classified as image" seems a better solution.

## How Has This Been Tested?

I added some test in the fixtures used to test the existing code. I am open on adding more. 

## Changelog Entry

<!--- Please write the changelog entry for these changes. -->
<!--- Follow the <https://keepachangelog.com/en/1.0.0/> format. -->
<!--- Use one of the Added, Changed, Deprecated, Removed, Fixed, and Security headers accordingly. -->

````
### Added

- Allow to block upload by setting a type (eg 'text/'), and not just a type and subtype (e.g. 'text/xml').
````

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] My code follows the code style of this project.
- [X] I have updated the documentation accordingly.
- [X] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [X] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
