### PR TITLE
ci: migrate from manual uploader to codecov-action v5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,13 +36,13 @@ jobs:
         run: cargo llvm-cov --lcov --output-path lcov.info -- --test-threads 1
         env:
           OUT_DIR: target
-      - name: Upload reports to codecov
-        run: |
-          curl -Os https://uploader.codecov.io/latest/linux/codecov
-          chmod +x codecov
-          ./codecov -t ${CODECOV_TOKEN} -f lcov.info
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: lcov.info
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false
+          verbose: true
 
   fixtures:
     strategy:


### PR DESCRIPTION
## Description

Migrate from manual Codecov CLI binary download to the official `codecov/codecov-action@v5` GitHub Action.

(Migration guide: https://docs.codecov.com/docs/deprecated-uploader-migration-guide)

## Motivation and Context

The current approach manually downloads and runs the Codecov uploader binary. The official recommendation is to use the `codecov-action` GitHub Action.

(Reference: https://about.codecov.io/blog/codecov-uploader-deprecation-plan/)

## How Has This Been Tested?

- Verified the workflow YAML syntax is valid
- The action parameters match the existing functionality:
  - Same coverage file: `lcov.info`
  - Same token authentication via `CODECOV_TOKEN` secret, no need to update anything
- This change only affects the upload mechanism, not coverage generation (cargo-llvm-cov)
- The existing `codecov.yml` configuration will continue to work as it is read server-side

## Changelog Entry

### Changed

- Migrate CI coverage upload from manual binary download to `codecov/codecov-action@v5`

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [x] Refactor (refactoring production code)
- [x] Other (CI/CD maintenance)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [ ] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [ ] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

> CI will verify this upon PR submission.