### PR TITLE
feat(paste): improve compound extension detection using mime_guess

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1435,9 +1435,9 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "mime_guess"
-version = "2.0.4"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4192263c238a5f0d0c6bfd21f336a313a4ce1c450542449ca191bb657b4642ef"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
 dependencies = [
  "mime",
  "unicase",
@@ -2023,6 +2023,7 @@ dependencies = [
  "infer",
  "lazy-regex",
  "mime",
+ "mime_guess",
  "path-clean",
  "petname",
  "rand 0.10.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
 uts2ts = "1.0.0"
 path-clean = "1.0.1"
+mime_guess = "2.0.5"
 
 [dependencies.config]
 version = "0.15.23"

--- a/src/paste.rs
+++ b/src/paste.rs
@@ -146,7 +146,10 @@ impl Paste {
             util::safe_path_join(self.type_.get_path(&config.server.upload_path)?, &file_name)?;
 
         let mut extension = match util::get_extension_from_filename(&file_name) {
-            Some(ext) => ext,
+            Some(ext) => {
+                file_name.truncate(file_name.len() - ext.len() - 1);
+                ext
+            }
             None => file_type
                 .map(|t| t.extension())
                 .unwrap_or(&config.paste.default_extension)

--- a/src/paste.rs
+++ b/src/paste.rs
@@ -144,33 +144,15 @@ impl Paste {
 
         let mut path =
             util::safe_path_join(self.type_.get_path(&config.server.upload_path)?, &file_name)?;
-        let mut parts: Vec<&str> = file_name.split('.').collect();
-        let mut dotfile = false;
-        let mut lower_bound = 1;
-        let mut file_name = match parts[0] {
-            "" => {
-                // Index shifts one to the right in the array for the rest of the string (the extension)
-                dotfile = true;
-                lower_bound = 2;
-                // If the first array element is empty, it means the file started with a dot (e.g.: .foo)
-                format!(".{}", parts[1])
-            }
-            _ => parts[0].to_string(),
-        };
-        let mut extension = if parts.len() > lower_bound {
-            // To get the rest (the extension), we have to remove the first element of the array, which is the filename
-            parts.remove(0);
-            if dotfile {
-                // If the filename starts with a dot, we have to remove another element, because the first element was empty
-                parts.remove(0);
-            }
-            parts.join(".")
-        } else {
-            file_type
+
+        let mut extension = match util::get_extension_from_filename(&file_name) {
+            Some(ext) => ext,
+            None => file_type
                 .map(|t| t.extension())
                 .unwrap_or(&config.paste.default_extension)
-                .to_string()
+                .to_string(),
         };
+
         let mut no_extension = false;
         if let Some(random_url) = &config.paste.random_url {
             if let Some(random_text) = random_url.generate() {

--- a/src/util.rs
+++ b/src/util.rs
@@ -56,14 +56,14 @@ pub fn glob_match_file(mut path: PathBuf) -> Result<PathBuf, ActixError> {
     Ok(path)
 }
 
-/// Attempts to extract the full file extension (including compound extensions, e.g. ".tar.gz")
-/// from a given file path.
+/// Attempts to extract the full file extension (including compound extensions, e.g. `tar.gz`)
+/// from a given file path. Returns the extension without a leading dot.
 ///
 /// Returns `None` for files without an extension or for hidden files
-/// with only a leading dot (e.g., ".gitignore").
+/// with only a leading dot (e.g., `.gitignore`).
 ///
-/// If a known MIME type is detected for a compound
-/// extension, it is returned; otherwise, falls back to the standard extension.
+/// If a known MIME type is detected for a compound extension, it is returned;
+/// otherwise, falls back to the standard single extension.
 pub fn get_extension_from_filename(file_path: &str) -> Option<String> {
     let path = Path::new(file_path);
     let file_name = path.file_name()?.to_str()?;
@@ -80,17 +80,23 @@ pub fn get_extension_from_filename(file_path: &str) -> Option<String> {
         return None;
     }
 
-    // Attempt to mime guess the extension after the first dot
+    // Attempt to mime guess the extension after the first dot.
+    // When the first (longest) candidate doesn't match but a shorter one does,
+    // also check whether the immediately preceding part is itself a known type —
+    // this handles compound extensions like "tar.gz" where only "gz" is in the
+    // mime_guess database but "tar" is also a recognised format.
     for i in start_index..parts.len() {
         let potential_ext = parts[i..].join(".");
-        let guesses = mime_guess::from_ext(&potential_ext);
-        if !guesses.is_empty() {
-            return Some(format!(".{}", potential_ext));
+        if !mime_guess::from_ext(&potential_ext).is_empty() {
+            if i > start_index && !mime_guess::from_ext(parts[i - 1]).is_empty() {
+                return Some(parts[i - 1..].join("."));
+            }
+            return Some(potential_ext);
         }
     }
 
     path.extension()
-        .map(|ext| format!(".{}", ext.to_string_lossy()))
+        .map(|ext| ext.to_string_lossy().into_owned())
 }
 
 /// Returns the found expired files in the possible upload locations.
@@ -515,5 +521,32 @@ mod tests {
         assert!(!is_disallowed_ipv6(Ipv6Addr::new(
             0x2607, 0xf8b0, 0x4004, 0x800, 0, 0, 0, 0x200e
         )));
+    }
+
+    #[test]
+    fn test_get_extension_from_filename() {
+        assert_eq!(
+            Some("txt".to_string()),
+            get_extension_from_filename("foo.txt")
+        );
+        assert_eq!(
+            Some("tar.gz".to_string()),
+            get_extension_from_filename("archive.tar.gz")
+        );
+        assert_eq!(
+            Some("tar.gz".to_string()),
+            get_extension_from_filename("/some/path/archive.tar.gz")
+        );
+        // Dotfile with no extension
+        assert_eq!(None, get_extension_from_filename(".gitignore"));
+        // Dotfile with extension
+        assert_eq!(
+            Some("txt".to_string()),
+            get_extension_from_filename(".hidden.txt")
+        );
+        // No extension
+        assert_eq!(None, get_extension_from_filename("Makefile"));
+        // Empty string
+        assert_eq!(None, get_extension_from_filename(""));
     }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -56,6 +56,43 @@ pub fn glob_match_file(mut path: PathBuf) -> Result<PathBuf, ActixError> {
     Ok(path)
 }
 
+/// Attempts to extract the full file extension (including compound extensions, e.g. ".tar.gz")
+/// from a given file path.
+///
+/// Returns `None` for files without an extension or for hidden files
+/// with only a leading dot (e.g., ".gitignore").
+///
+/// If a known MIME type is detected for a compound
+/// extension, it is returned; otherwise, falls back to the standard extension.
+pub fn get_extension_from_filename(file_path: &str) -> Option<String> {
+    let path = Path::new(file_path);
+    let file_name = path.file_name()?.to_str()?;
+    let parts: Vec<&str> = file_name.split('.').collect();
+
+    // Ignore names with no dot
+    if parts.len() < 2 {
+        return None;
+    }
+
+    // Ignore hidden files with only a single leading dot (e.g., ".gitignore")
+    let start_index = if parts[0].is_empty() { 2 } else { 1 };
+    if parts.len() <= start_index {
+        return None;
+    }
+
+    // Attempt to mime guess the extension after the first dot
+    for i in start_index..parts.len() {
+        let potential_ext = parts[i..].join(".");
+        let guesses = mime_guess::from_ext(&potential_ext);
+        if !guesses.is_empty() {
+            return Some(format!(".{}", potential_ext));
+        }
+    }
+
+    path.extension()
+        .map(|ext| format!(".{}", ext.to_string_lossy()))
+}
+
 /// Returns the found expired files in the possible upload locations.
 ///
 /// Fail-safe, omits errors.


### PR DESCRIPTION
<!--- Thank you for contributing to rustypaste! -->

## Description

Extracts the inline file extension parsing from `Paste::store_file` into a new
`util::get_extension_from_filename` helper.

The helper uses `mime_guess` to detect compound extensions (e.g. `tar.gz`): it
iterates candidate suffixes from longest to shortest and, when a known
compression/archive suffix is found (e.g. `gz`), also checks whether the immediately
preceding part is itself a recognized type (e.g. `tar`) — returning the combined form
(`tar.gz`) when it is.

Falls back to `Path::extension` for single-component or unknown
extensions.

## Motivation and Context

The previous parsing logic treated everything after the first dot as the extension, so a
file like `foo.bar.baz.txt` would produce `<random>.bar.baz.txt` in suffix mode despite
being a plain text file. The new helper uses `mime_guess` to identify only meaningful
extensions: single ones like `.txt`, and genuine compound formats like `.tar.gz` where
both components are recognized types.

## How Has This Been Tested?

- Existing `paste::tests::test_paste_data` covers `store_file` end-to-end for plain
  extensions, compound extensions (`foo.tar.gz`, `.foo.tar.gz`), dotfiles, and
  random-URL suffix mode.
- New `util::tests::test_get_extension_from_filename` unit-test to test the helper

## Changelog Entry

```
### Changed

- Extract file extension parsing into `util::get_extension_from_filename`.
  - Uses `mime_guess` to correctly detect compound extensions (e.g. `tar.gz`) while
    avoiding treating every dot-separated segment as part of the extension.
```

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [x] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.