### PR TITLE
fix(lints): apply clippy suggestions

### DIFF
--- a/src/paste.rs
+++ b/src/paste.rs
@@ -263,7 +263,7 @@ impl Paste {
         let file_name = url
             .path_segments()
             .and_then(|mut segments| segments.next_back())
-            .and_then(|name| if name.is_empty() { None } else { Some(name) })
+            .filter(|&name| !name.is_empty())
             .unwrap_or("file");
         let mut response = client
             .get(url.as_str())


### PR DESCRIPTION
Fixes:

```
warning: manual implementation of `Option::filter`
   --> src/paste.rs:266:14
    |
266 |             .and_then(|name| if name.is_empty() { None } else { Some(name) })
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `filter(|&name| !name.is_empty())`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.97.0/index.html#manual_filter
    = note: `#[warn(clippy::manual_filter)]` on by default
```