### PR TITLE
refactor(ci): mergify queue merge_method sqash

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,3 +1,7 @@
+queue_rules:
+  - name: default
+    merge_method: squash
+
 pull_request_rules:
   - name: Automatic merge for Dependabot pull requests
     conditions:


### PR DESCRIPTION
Tell the mergify bot to use `squash` when using the merge queue.