### PR TITLE
feat(server): support deletion of all item types

### DIFF
--- a/fixtures/test-url-delete/config.toml
+++ b/fixtures/test-url-delete/config.toml
@@ -1,0 +1,9 @@
+[server]
+address = "127.0.0.1:8000"
+max_content_length = "10MB"
+upload_path = "./upload"
+delete_tokens = ["may_the_force_be_with_you"]
+
+[paste]
+default_extension = "txt"
+duplicate_files = false

--- a/fixtures/test-url-delete/test.sh
+++ b/fixtures/test-url-delete/test.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+url="https://orhun.dev/"
+
+setup() {
+  :;
+}
+
+run_test() {
+  url_url=$(curl -s -F "url=$url" localhost:8000)
+  test "$url" = "$(cat upload/url/url)"
+  test "$url_url" = "http://localhost:8000/url"
+  test "file deleted" = "$(curl -s -H "Authorization: may_the_force_be_with_you" -X DELETE http://localhost:8000/url)"
+  test "file is not found or expired :(" = "$(curl -s -H "Authorization: may_the_force_be_with_you" -X DELETE http://localhost:8000/url)"
+}
+
+teardown() {
+  rm -r upload
+}

--- a/src/server.rs
+++ b/src/server.rs
@@ -259,7 +259,16 @@ async fn delete(
     let config = config
         .read()
         .map_err(|_| error::ErrorInternalServerError("cannot acquire config"))?;
-    let mut path = util::glob_match_file(safe_path_join(&config.server.upload_path, &*file)?)?;
+    let mut path = PathBuf::new();
+    for variant in PASTE_VARIANTS_LIST {
+        path = util::glob_match_file(safe_path_join(
+            variant.get_path(&config.server.upload_path)?,
+            &*file,
+        )?)?;
+        if path.exists() && path.is_file() {
+            break;
+        }
+    }
     if !path.is_file() || !path.exists() {
         let protected_path = safe_path_join(
             PasteType::ProtectedFile.get_path(&config.server.upload_path)?,


### PR DESCRIPTION
<!--- Thank you for contributing to rustypaste! -->

## Description

This PR allows the deletion of all item types: files, urls, oneshot, and oneshot_url.

## Motivation and Context

see https://github.com/orhun/rustypaste/pull/587#issuecomment-4961885687

## How Has This Been Tested?

manual testing
added fixture

## Changelog Entry

<!--- Please write the changelog entry for these changes. -->
<!--- Follow the <https://keepachangelog.com/en/1.0.0/> format. -->
<!--- Use one of the Added, Changed, Deprecated, Removed, Fixed, and Security headers accordingly. -->

````
### Added

- Add support for deleting all item types (files, urls, oneshot, and oneshot_url)
````


## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
