### PR TITLE
refactor(ci): use ubuntu-latest to minimize glibc issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   check:
     name: Check
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v7
@@ -24,7 +24,7 @@ jobs:
 
   test:
     name: Test suite
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v7
@@ -50,7 +50,7 @@ jobs:
       matrix:
         os:
           - name: Linux
-            runner: ubuntu-22.04
+            runner: ubuntu-latest
           - name: macOS
             runner: macos-14
     name: Test fixtures [${{ matrix.os.name }}]
@@ -74,7 +74,7 @@ jobs:
 
   clippy:
     name: Lints
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v7
@@ -87,7 +87,7 @@ jobs:
 
   rustfmt:
     name: Formatting
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v7
@@ -100,7 +100,7 @@ jobs:
 
   lychee:
     name: Links
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v7


### PR DESCRIPTION
Let's see, if this fixes the glibc incompat issues.