### PR TITLE
fix(server): retrieval of password-protected files

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -134,20 +134,26 @@ async fn serve(
     }
 
     // Check password protection
-    if crate::password::has_password(&path) {
-        use actix_web::http::header::AUTHORIZATION;
+    if paste_type == PasteType::ProtectedFile {
+        if crate::password::has_password(&path) {
+            use actix_web::http::header::AUTHORIZATION;
 
-        let password = request
-            .headers()
-            .get(AUTHORIZATION)
-            .and_then(|v| v.to_str().ok())
-            .and_then(extract_password_from_auth)
-            .ok_or_else(|| error::ErrorNotFound("file is not found or expired :(\n"))?;
+            let password = request
+                .headers()
+                .get(AUTHORIZATION)
+                .and_then(|v| v.to_str().ok())
+                .and_then(extract_password_from_auth)
+                .ok_or_else(|| error::ErrorNotFound("file is not found or expired :(\n"))?;
 
-        if !crate::password::verify_file_password(&path, &password)
-            .map_err(|e| error::ErrorInternalServerError(format!("password verification: {e}")))?
-        {
-            // Same error as missing file (prevents enumeration)
+            if !crate::password::verify_file_password(&path, &password).map_err(|e| {
+                error::ErrorInternalServerError(format!("password verification: {e}"))
+            })? {
+                // Same error as missing file (prevents enumeration)
+                info!("PasteType::ProtectedFile: password verification failed");
+                return Err(error::ErrorNotFound("file is not found or expired :(\n"));
+            }
+        } else {
+            error!("PasteType::ProtectedFile: no password metadata file");
             return Err(error::ErrorNotFound("file is not found or expired :(\n"));
         }
     }

--- a/src/server.rs
+++ b/src/server.rs
@@ -143,7 +143,10 @@ async fn serve(
                 .get(AUTHORIZATION)
                 .and_then(|v| v.to_str().ok())
                 .and_then(extract_password_from_auth)
-                .ok_or_else(|| error::ErrorNotFound("file is not found or expired :(\n"))?;
+                .ok_or_else(|| {
+                    info!("PasteType::ProtectedFile: cannot extract password from headers");
+                    error::ErrorNotFound("file is not found or expired :(\n")
+                })?;
 
             if !crate::password::verify_file_password(&path, &password).map_err(|e| {
                 error::ErrorInternalServerError(format!("password verification: {e}"))

--- a/src/util.rs
+++ b/src/util.rs
@@ -40,6 +40,14 @@ pub fn glob_match_file(mut path: PathBuf) -> Result<PathBuf, ActixError> {
     );
     if let Some(glob_path) = glob(&format!("{}.[0-9]*", path.to_string_lossy()))
         .map_err(error::ErrorInternalServerError)?
+        .filter(|r| {
+            // we do not want password files, otherwise further processing fails
+            r.as_ref()
+                .ok()
+                .and_then(|p| p.extension())
+                .and_then(|e| e.to_str())
+                != Some("password")
+        })
         .last()
     {
         let glob_path = glob_path.map_err(error::ErrorInternalServerError)?;


### PR DESCRIPTION
## Description

This PR fixes the retrieval of password-protected files.

I finally figured out what is going on. The function `glob_match_file` also retrieves the `.password` files and consequently further processing is messed up.

I have also added an info message on the server, if password verification fails. The end user will not see this message, thus enumeration is still prevented.

During this debugging session I also came across an edge case that would allow the retrieval of a protected file without a password: if the `.password` file were to be deleted on the server (in the `protected` directory), one could retrieve the file without a password.
This is no longer possible.

## Motivation and Context

see https://github.com/orhun/rustypaste/pull/505#issuecomment-4956323666

## How Has This Been Tested?

- manually
- cargo test
- fixtures

## Changelog Entry

<!--- Please write the changelog entry for these changes. -->
<!--- Follow the <https://keepachangelog.com/en/1.0.0/> format. -->
<!--- Use one of the Added, Changed, Deprecated, Removed, Fixed, and Security headers accordingly. -->

````
### Fixed

- Retrieval of password-protected files
````


## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
